### PR TITLE
Update for k8s v1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ You can interface with the OpenStudio-server cluster using the [Parametric Analy
 
 ## Prerequisites
 
-- Kubernetes 1.3+ cluster.  Please refer to cluster setup instructions for [google](/google/README.md) or [aws](/aws/README.md) for information on how to provision a cluster. 
-- [helm client](https://helm.sh/docs/intro/install/)
-- [kubectl client](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- Kubernetes 1.6+ cluster.  Please refer to cluster setup instructions for [google](/google/README.md) or [aws](/aws/README.md) for information on how to provision a cluster. 
+- [helm client](https://helm.sh/docs/intro/install/) (v3.4.2 or higher)
+- [kubectl client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (v1.20.0 or higher) 
 
 ## Installing the Chart
 
@@ -37,16 +37,16 @@ The command removes all the Kubernetes components associated with the chart and 
 The following table lists the configurable parameters of the OpenStudio-server chart and their default values. You can override any of these values by specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example, to change the data storage for NFS which stores the data points to 300GB you would run this install command:
 
 For Google  
-`$ helm install openstudio-server ./openstudio-server --set provider.name=google --set nfs-server-provisioner.persistence.size=300GB`
+`$ helm install openstudio-server ./openstudio-server --set provider.name=google --set nfs-server-provisioner.persistence.size=300Gi`
 
 For Amazon  
-`$ helm install openstudio-server ./openstudio-server --set provider.name=aws --set nfs-server-provisioner.persistence.size=300GB`
+`$ helm install openstudio-server ./openstudio-server --set provider.name=aws --set nfs-server-provisioner.persistence.size=300Gi`
 
 
 Parameter | Description | Default
 --------- | ----------- | -------
-nfs-server-provisioner.persistence.size | Size of the volume for storing the data point results | 200GB |
-db.persistence.size | Size of the volume for MongoDB | 200GB |
+nfs-server-provisioner.persistence.size | Size of the volume for storing the data point results | 200Gi |
+db.persistence.size | Size of the volume for MongoDB | 200Gi |
 cluster.name | Kubernetes AWS or Google cluster name. If you change the default name you need to set this name here otherwise AWS auto-scaling will not work correctly | openstudio-server |
 worker_hpa.minReplicas | Worker pods that run the simulations | 1 |
 worker_hpa.maxReplicas | Maximum Worker pods that run the simulations | 20 |

--- a/aws/README.md
+++ b/aws/README.md
@@ -4,27 +4,27 @@ Below is a guide to help setup a AWS Elastic Kubernetes Cluster (EKS) cluster us
 ## Prerequisites
 
 - AWS Account with EKS privileges
-- AWS [eksctl client](https://docs.aws.amazon.com/eks/latest/userguide/eksctl)
+- AWS [eksctl client](https://docs.aws.amazon.com/eks/latest/userguide/eksctl) (v0.34.0 or higher)
 
 ## Install eksctl client
-https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html#installing-eksctl
+https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html#installing-eksctl (0.34.0 or higher)
 
 
 ## Create a cluster using eksctl
 
-eksctl will need access to AWS. You can provide access via ENV variables (example below). More advanced info on eksctl can be found here: https://eksctl.io/
+eksctl will need access to AWS. You can provide access by setting ENV variables in your shell before running the cli (example below). More advanced info on eksctl can be found here: https://eksctl.io/
 
 ```
-$ export AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID"
-$ export AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_ACCESS_KEY"
-$ export AWS_DEFAULT_REGION="YOUR_AWS_DEFAULT_REGION"
+$  export AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID"
+$  export AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_ACCESS_KEY"
+$  export AWS_DEFAULT_REGION="YOUR_AWS_DEFAULT_REGION"
 ```
 Below is an example that will create an AWS EKS cluster that has 3 nodes of instance type `t2.xlarge` with max nodes = 8. This cluster is set to autoscale up to this max node amount. You can change the instance type and min and max node setting to your use case.  More info on [AWS instance types](https://aws.amazon.com/ec2/instance-types/)
 
 ```
 $ eksctl create cluster \
     --name openstudio-server \
-    --version 1.14 \
+    --version 1.18 \
     --region us-west-2 \
     --nodegroup-name standard-workers \
     --node-type t2.xlarge\
@@ -36,6 +36,50 @@ $ eksctl create cluster \
     --ssh-public-key ~/.ssh/id_rsa.pub \
     --managed
 ```
+
+This is an example of the output you should see when you create the cluster: 
+
+```
+[ℹ]  eksctl version 0.34.0
+[ℹ]  using region us-west-2
+[ℹ]  setting availability zones to [us-west-2a us-west-2d us-west-2c]
+[ℹ]  subnets for us-west-2a - public:192.168.0.0/19 private:192.168.96.0/19
+[ℹ]  subnets for us-west-2d - public:192.168.32.0/19 private:192.168.128.0/19
+[ℹ]  subnets for us-west-2c - public:192.168.64.0/19 private:192.168.160.0/19
+[ℹ]  using SSH public key "/Users/tijcolem/.ssh/id_rsa.pub" as "eksctl-openstudio-server-nodegroup-standard-workers-8d:9e:ea:30:c1:55:57:67:3a:0e:f8:73:68:79:92:a9" 
+[ℹ]  using Kubernetes version 1.18
+[ℹ]  creating EKS cluster "openstudio-server" in "us-west-2" region with managed nodes
+[ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial managed nodegroup
+[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=openstudio-server'
+[ℹ]  CloudWatch logging will not be enabled for cluster "openstudio-server" in "us-west-2"
+[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=us-west-2 --cluster=openstudio-server'
+[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "openstudio-server" in "us-west-2"
+[ℹ]  2 sequential tasks: { create cluster control plane "openstudio-server", 3 sequential sub-tasks: { no tasks, create addons, create managed nodegroup "standard-workers" } }
+[ℹ]  building cluster stack "eksctl-openstudio-server-cluster"
+[ℹ]  deploying stack "eksctl-openstudio-server-cluster"
+
+[ℹ]  building managed nodegroup stack "eksctl-openstudio-server-nodegroup-standard-workers"
+[ℹ]  deploying stack "eksctl-openstudio-server-nodegroup-standard-workers"
+[ℹ]  waiting for the control plane availability...
+[✔]  saved kubeconfig as "/Users/tijcolem/.kube/config"
+[ℹ]  no tasks
+[✔]  all EKS cluster resources for "openstudio-server" have been created
+[ℹ]  nodegroup "standard-workers" has 3 node(s)
+[ℹ]  node "ip-192-168-1-231.us-west-2.compute.internal" is ready
+[ℹ]  node "ip-192-168-2-125.us-west-2.compute.internal" is ready
+[ℹ]  node "ip-192-168-81-118.us-west-2.compute.internal" is ready
+[ℹ]  waiting for at least 3 node(s) to become ready in "standard-workers"
+[ℹ]  nodegroup "standard-workers" has 3 node(s)
+[ℹ]  node "ip-192-168-1-231.us-west-2.compute.internal" is ready
+[ℹ]  node "ip-192-168-2-125.us-west-2.compute.internal" is ready
+[ℹ]  node "ip-192-168-81-118.us-west-2.compute.internal" is ready
+[ℹ]  kubectl command should work with "/Users/tijcolem/.kube/config", try 'kubectl get nodes'
+[✔]  EKS cluster "openstudio-server" in "us-west-2" region is ready
+```
+
+## Connecting to your cluster using kubectl
+
+Once eksctl is done setting up the cluster, it will automatically setup the connection by creating a `~/.kube/config` file so you and can begin using helm and kubectl cli tools to communicate to the cluster.  occasionally, you need to run generate this config manually. If you are not able to run `kubectl get nodes` you can re-run the kube config setup by running `aws eks update-kubeconfig --name openstudio-server`  Change the `--name` to match the cluster name if different from the example.  
 
 ## Delete the cluster using eksctl
 

--- a/openstudio-server/Chart.yaml
+++ b/openstudio-server/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.1
+appVersion: 3.0.1-1
 
 # This is an offical helm chart: https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner
 # openstudio-sever modfied this slighly to use deployment vs stateful sets as helm does not automatically 

--- a/openstudio-server/Chart.yaml
+++ b/openstudio-server/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.1-1
+appVersion: 3.1.0
 
 # This is an offical helm chart: https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner
 # openstudio-sever modfied this slighly to use deployment vs stateful sets as helm does not automatically 

--- a/openstudio-server/templates/db/db-deploy.yaml
+++ b/openstudio-server/templates/db/db-deploy.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.db.name }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.db.name  }}
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -12,7 +16,8 @@ spec:
   template:
     metadata:
       labels:
-        label: {{ .Values.db.name }}
+        app: {{ .Values.db.name }}
+        release: {{ .Release.Name }}
     spec:
       containers:
         - name: {{ .Values.db.container.name }}

--- a/openstudio-server/templates/db/db-svc.yaml
+++ b/openstudio-server/templates/db/db-svc.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ .Values.db.name  }}
 spec:
   selector:
-    label: {{ .Values.db.label  }}
+    app: {{ .Values.db.label  }}
+    release: {{ .Release.Name }}
   ports:
     - name: {{ .Values.db.name  }}
       protocol: TCP

--- a/openstudio-server/templates/loadbalancer/loadbalancer.yaml
+++ b/openstudio-server/templates/loadbalancer/loadbalancer.yaml
@@ -6,7 +6,8 @@ spec:
   type: LoadBalancer
   externalTrafficPolicy:  {{ .Values.load_balancer.externalTrafficPolicy }}
   selector:
-    label: {{ .Values.load_balancer.selector.label }}
+    app: {{ .Values.load_balancer.label }}
+    release: {{ .Release.Name }}
   ports:
     - name: {{ .Values.load_balancer.ports.http_name }}
       protocol: {{ .Values.load_balancer.ports.http_protocol }} 

--- a/openstudio-server/templates/redis/redis-deploy.yaml
+++ b/openstudio-server/templates/redis/redis-deploy.yaml
@@ -1,13 +1,18 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.redis.name  }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.redis.name  }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ .Values.redis.name  }}
+        release: {{ .Release.Name }}
     spec:
       containers:
         - name: {{ .Values.redis.container.name  }}

--- a/openstudio-server/templates/redis/redis-svc.yaml
+++ b/openstudio-server/templates/redis/redis-svc.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ .Values.redis_svc.name  }}
 spec:
   selector:
-    app: {{ .Values.redis_svc.selector.app  }}
+    app: {{ .Values.redis.name  }}
+    release: {{ .Release.Name }}
   ports:
     - name: redis
       protocol: TCP

--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.rserve.name  }} 
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.rserve.name }}
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -12,7 +16,8 @@ spec:
   template:
     metadata:
       labels:
-        label: {{ .Values.rserve.label }}  
+        app: {{ .Values.rserve.name }}
+        release: {{ .Release.Name }}
     spec:
       containers:
         - name: {{ .Values.rserve.container.name }} 

--- a/openstudio-server/templates/rserve/rserve-svc.yaml
+++ b/openstudio-server/templates/rserve/rserve-svc.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ .Values.rserve_svc.name  }}
 spec:
   selector:
-    label: {{ .Values.rserve_svc.label  }}
+    app: {{ .Values.db.label  }}
+    release: {{ .Release.Name }}
   ports:
     - name: rserve
       protocol: TCP

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{  .Values.web_background.name  }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{  .Values.web_background.name  }}
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -12,7 +16,8 @@ spec:
   template:
     metadata:
       labels:
-        label: {{  .Values.web_background.label  }}
+        app: {{  .Values.web_background.name  }}
+        release: {{ .Release.Name }}
     spec:
       containers:
         - name:  {{  .Values.web_background.container.name  }}

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.web.name  }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.web.name  }}
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -12,7 +16,8 @@ spec:
   template:
     metadata:
       labels:
-        label: {{ .Values.web.label  }}
+        app: {{ .Values.web.name  }}
+        release: {{ .Release.Name }}
     spec:
       containers:
         - name:  {{ .Values.web.container.name  }}

--- a/openstudio-server/templates/web/web-svc.yaml
+++ b/openstudio-server/templates/web/web-svc.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ .Values.web_svc.name   }}
 spec:
   selector:
-    label: {{ .Values.web_svc.label   }}
+    app: {{ .Values.web.name  }}
+    release: {{ .Release.Name }}
   ports:
     - name: http
       protocol: TCP

--- a/openstudio-server/templates/worker/worker-deploy.yaml
+++ b/openstudio-server/templates/worker/worker-deploy.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.worker.name   }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.worker.name }}
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -12,7 +16,8 @@ spec:
   template:
     metadata:
       labels:
-        label: {{ .Values.worker.label  }}
+        app: {{ .Values.worker.name }}
+        release: {{ .Release.Name }}
     spec:
       containers:
         - name: {{ .Values.worker.container.name   }}

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -37,8 +37,7 @@ db:
 load_balancer:
   name: "ingress-load-balancer"
   externalTrafficPolicy: "Local"
-  selector:
-    label: "web"
+  label: "web"
   ports:
     http_name: "http" 
     http_port: 80
@@ -60,6 +59,7 @@ nfs_pvc:
 
 redis:
   name: "redis"
+  label: "redis"
   container:
     name: "redis"
     image: "redis:4.0.6"
@@ -69,8 +69,7 @@ redis:
 
 redis_svc:
   name: "queue"
-  selector:
-   app: "redis"
+  label: "redis"
   port: 6379
 
 
@@ -112,8 +111,6 @@ web:
 web_svc: 
   name: "web" 
   label: "web" 
-  selector:
-    label: "web"
   ports:
     http: 80 
     https: 443

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -79,7 +79,7 @@ rserve:
   label: "rserve" 
   container:
     name: "rserve"
-    image: "nrel/openstudio-rserve:3.0.1"
+    image: "nrel/openstudio-rserve:3.0.1-1"
     cpu: 1
     memory: 2Gi
     
@@ -93,7 +93,7 @@ web_background:
   label: "web-background" 
   container:
     name: "web-background" 
-    image: "nrel/openstudio-server:3.0.1" 
+    image: "nrel/openstudio-server:3.0.1-1" 
     cpu: 1
     memory: "3Gi"
 
@@ -102,7 +102,7 @@ web:
   label: "web"
   container:
     name: "web"
-    image: "nrel/openstudio-server:3.0.1"
+    image: "nrel/openstudio-server:3.0.1-1"
     cpu: 1
     memory: "1Gi"
     port:
@@ -124,7 +124,7 @@ worker:
   label: "worker" 
   container:
     name: "worker"
-    image: "nrel/openstudio-server:3.0.1"
+    image: "nrel/openstudio-server:3.0.1-1"
     cpu: 1
     memory: "3Gi"
     terminationGracePeriodSeconds: 3600


### PR DESCRIPTION
Update k8s to use newer versions of k8s v1.18 
Update eksctl, kubectl and helm versions for compatibility to work with v1.18
Update AWS notes 
