### PR TITLE
Scale Web Pods

### DIFF
--- a/openstudio-server/templates/db/db-deploy.yaml
+++ b/openstudio-server/templates/db/db-deploy.yaml
@@ -27,6 +27,10 @@ spec:
           volumeMounts:
             - mountPath: /data/db
               name: {{ .Values.db.name }}
+          resources:
+            requests:
+              cpu: {{ .Values.db.container.cpu   }}
+              memory: {{ .Values.db.container.memory   }}
       volumes:
         - name: {{ .Values.db.name }}
           persistentVolumeClaim:

--- a/openstudio-server/templates/redis/redis-deploy.yaml
+++ b/openstudio-server/templates/redis/redis-deploy.yaml
@@ -23,3 +23,11 @@ spec:
               memory: {{ .Values.redis.container.memory  }}
           ports:
             - containerPort: {{ .Values.redis.container.port  }}
+          volumeMounts:
+            - mountPath: /data
+              name: {{ .Values.redis.name }}
+#          args: ["--appendonly", "yes", "--save", "900", "1", "--save", "30", "1"]
+      volumes:
+        - name: {{ .Values.redis.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.name }}

--- a/openstudio-server/templates/redis/redis-pvc.yaml
+++ b/openstudio-server/templates/redis/redis-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.redis.name  }}
+spec:
+  storageClassName: {{ .Values.redis.persistence.storageClass }}
+  accessModes:
+    {{ .Values.redis.persistence.accessModes }}
+  resources:
+    requests:
+      storage:  {{ .Values.redis.persistence.size }}

--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -29,6 +29,13 @@ spec:
           volumeMounts:
             - name: osdata
               mountPath: "/mnt/openstudio"
+          livenessProbe:
+            exec:
+              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
       volumes:
         - name: osdata
           persistentVolumeClaim:

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -35,6 +35,13 @@ spec:
             - name: QUEUES
               value: background,analyses
           command: ["/usr/local/bin/start-web-background"]
+          livenessProbe:
+            exec:
+              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
       volumes:
         - name: nfs
           persistentVolumeClaim:

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -44,6 +44,14 @@ spec:
               port: 80
             initialDelaySeconds: 5
             periodSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /about
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
       volumes:
        - name: nfs
          persistentVolumeClaim:

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -38,12 +38,12 @@ spec:
             - name: QUEUES
               value: analysis_wrappers
           command: ["bash", "-c", "/usr/local/bin/rails-entrypoint && /usr/local/bin/start-server"]
-      readinessProb:
-        httpGet:
-          path: /
-          port: 80
-        initialDelaySeconds: 5
-        periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 3
       volumes:
        - name: nfs
          persistentVolumeClaim:

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -38,6 +38,12 @@ spec:
             - name: QUEUES
               value: analysis_wrappers
           command: ["bash", "-c", "/usr/local/bin/rails-entrypoint && /usr/local/bin/start-server"]
+      readinessProb:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 5
+        periodSeconds: 3
       volumes:
        - name: nfs
          persistentVolumeClaim:

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -45,9 +45,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 3
           livenessProbe:
-            httpGet:
-              path: /about
-              port: 80
+            exec:
+              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
             initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 30

--- a/openstudio-server/templates/web/web-hpa.yaml
+++ b/openstudio-server/templates/web/web-hpa.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.web.name  }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.web.name  }}
+  minReplicas: {{ .Values.web_hpa.minReplicas  }}
+  maxReplicas: {{ .Values.web_hpa.maxReplicas  }}
+  targetCPUUtilizationPercentage: {{ .Values.web_hpa.targetCPUUtilizationPercentage  }}

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -111,16 +111,19 @@ web:
   container:
     name: "web"
     image: "nrel/openstudio-server:3.1.0"
-    cpu: 1
-    memory: "3Gi"
+    cpu: 2
+    memory: "6Gi"
     port:
      http: 80
      https: 443
 
+# For this to work and have more than 1 web pod we'll need to implement 
+# a distrbuted file locking scheme such a https://github.com/antirez/redlock-rbs 
+# as even with using NFS via sync it cannot guarantee file locking using mutliple clients
 web_hpa:
   name: "web"
-  minReplicas: 2
-  maxReplicas: 10
+  minReplicas: 1
+  maxReplicas: 1
   targetCPUUtilizationPercentage: 50
 
 web_svc: 
@@ -142,7 +145,7 @@ worker:
       
 worker_hpa: 
   name: "worker"
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 20
   targetCPUUtilizationPercentage: 50
 

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -19,6 +19,7 @@ nfs-server-provisioner:
     allowVolumeExpansion: false
     mountOptions:
       - vers=4 
+      - sync
 db:
   name:  "db"
   label: "db"

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -69,6 +69,12 @@ redis:
     cpu: 0.5
     memory: "1G"
     port: 6379
+  persistence:
+    enabled: true
+    storageClass: "ssd"
+    size: 5Gi
+    accessModes:
+      - "ReadWriteOnce"
 
 redis_svc:
   name: "queue"

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -25,6 +25,8 @@ db:
   container:
     name: "mongo-db"
     image: "mongo:3.4.10"
+    cpu: 2
+    memory: "8Gi"
     ports:
       db_port: 27017
   persistence:
@@ -103,10 +105,16 @@ web:
     name: "web"
     image: "nrel/openstudio-server:3.1.0"
     cpu: 1
-    memory: "1Gi"
+    memory: "3Gi"
     port:
      http: 80
      https: 443
+
+web_hpa:
+  name: "web"
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 50
 
 web_svc: 
   name: "web" 
@@ -115,7 +123,6 @@ web_svc:
     http: 80 
     https: 443
 
-      
 worker:
   name: "worker" 
   label: "worker" 


### PR DESCRIPTION
Config changes to allow for web pod to scale via hpa and some other changes to allow for more robots workloads to account for pod crashes.  

Changes: 
Support for horizontal scale-out of web nodes (min 2, max 10)
added liveliness and readiness probes for critical pods to restart (e.g. mount failed)
Added persistence for redis in case redis queue crashes it can be restored when re-spawned. 

