### PR TITLE
Update to OpenStudio 3.2.0-rc1

### DIFF
--- a/openstudio-server/Chart.yaml
+++ b/openstudio-server/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.0
+appVersion: 3.2.0-rc1
 
 # This is an offical helm chart: https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner
 # openstudio-sever modfied this slighly to use deployment vs stateful sets as helm does not automatically 

--- a/openstudio-server/templates/db/db-deploy.yaml
+++ b/openstudio-server/templates/db/db-deploy.yaml
@@ -31,6 +31,11 @@ spec:
             requests:
               cpu: {{ .Values.db.container.cpu   }}
               memory: {{ .Values.db.container.memory   }}
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              value: {{ .Values.db.username }}
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              value: {{ .Values.db.password }}
       volumes:
         - name: {{ .Values.db.name }}
           persistentVolumeClaim:

--- a/openstudio-server/templates/redis/redis-deploy.yaml
+++ b/openstudio-server/templates/redis/redis-deploy.yaml
@@ -23,3 +23,12 @@ spec:
               memory: {{ .Values.redis.container.memory  }}
           ports:
             - containerPort: {{ .Values.redis.container.port  }}
+          volumeMounts:
+            - mountPath: /data
+              name: {{ .Values.redis.name }}
+#          args: ["--appendonly", "yes", "--save", "900", "1", "--save", "30", "1"]
+          args: ["redis-server", "--requirepass", "{{ .Values.redis.password  }}"]
+      volumes:
+        - name: {{ .Values.redis.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.name }}

--- a/openstudio-server/templates/redis/redis-pvc.yaml
+++ b/openstudio-server/templates/redis/redis-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.redis.name  }}
+spec:
+  storageClassName: {{ .Values.redis.persistence.storageClass }}
+  accessModes:
+    {{ .Values.redis.persistence.accessModes }}
+  resources:
+    requests:
+      storage:  {{ .Values.redis.persistence.size }}

--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -29,6 +29,9 @@ spec:
           volumeMounts:
             - name: osdata
               mountPath: "/mnt/openstudio"
+          env:
+            - name: SECRET_KEY_BASE
+              value: {{ .Values.web.secret_key_value }}
       volumes:
         - name: osdata
           persistentVolumeClaim:

--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -32,6 +32,13 @@ spec:
           env:
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
+          livenessProbe:
+            exec:
+              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
       volumes:
         - name: osdata
           persistentVolumeClaim:

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -34,6 +34,8 @@ spec:
               value: ${OS_SERVER_NUMBER_OF_WORKERS}
             - name: QUEUES
               value: background,analyses
+            - name: SECRET_KEY_BASE
+              value: {{ .Values.web.secret_key_value }}
           command: ["/usr/local/bin/start-web-background"]
       volumes:
         - name: nfs

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
         - name:  {{  .Values.web_background.container.name  }}
           image:  {{  .Values.web_background.container.image  }}
+          imagePullPolicy: Always
           resources:
             requests:
               cpu:  {{  .Values.web_background.container.cpu  }}
@@ -36,7 +37,20 @@ spec:
               value: background,analyses
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
+            - name: REDIS_URL
+              value: {{ .Values.redis_svc.url  }}
+            - name: MONGO_USER
+              value: {{ .Values.db.username }}
+            - name: MONGO_PASSWORD
+              value: {{ .Values.db.password }}
           command: ["/usr/local/bin/start-web-background"]
+          livenessProbe:
+            exec:
+              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
       volumes:
         - name: nfs
           persistentVolumeClaim:

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -37,6 +37,8 @@ spec:
               value: ${OS_SERVER_NUMBER_OF_WORKERS}
             - name: QUEUES
               value: analysis_wrappers
+            - name: SECRET_KEY_BASE
+              value: {{ .Values.web.secret_key_value }}
           command: ["bash", "-c", "/usr/local/bin/rails-entrypoint && /usr/local/bin/start-server"]
       volumes:
        - name: nfs

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -52,7 +52,8 @@ spec:
               path: /
               port: 80
             initialDelaySeconds: 5
-            periodSeconds: 3
+            periodSeconds: 30
+            failureThreshold: 5
           livenessProbe:
             exec:
               command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
         - name:  {{ .Values.web.container.name  }}
           image: {{ .Values.web.container.image  }}
+          imagePullPolicy: Always
           resources:
             requests:
               cpu: {{ .Values.web.container.cpu  }}
@@ -39,7 +40,26 @@ spec:
               value: analysis_wrappers
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
+            - name: REDIS_URL
+              value: {{ .Values.redis_svc.url  }}
+            - name: MONGO_USER
+              value: {{ .Values.db.username }}
+            - name: MONGO_PASSWORD
+              value: {{ .Values.db.password }}
           command: ["bash", "-c", "/usr/local/bin/rails-entrypoint && /usr/local/bin/start-server"]
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 3
+          livenessProbe:
+            exec:
+              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
       volumes:
        - name: nfs
          persistentVolumeClaim:

--- a/openstudio-server/templates/web/web-hpa.yaml
+++ b/openstudio-server/templates/web/web-hpa.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.web.name  }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.web.name  }}
+  minReplicas: {{ .Values.web_hpa.minReplicas  }}
+  maxReplicas: {{ .Values.web_hpa.maxReplicas  }}
+  targetCPUUtilizationPercentage: {{ .Values.web_hpa.targetCPUUtilizationPercentage  }}

--- a/openstudio-server/templates/worker/worker-deploy.yaml
+++ b/openstudio-server/templates/worker/worker-deploy.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
         - name: {{ .Values.worker.container.name   }}
           image: {{ .Values.worker.container.image   }}
+          imagePullPolicy: Always
           lifecycle:
             preStop:
               exec:
@@ -42,6 +43,12 @@ spec:
               value: "1"
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
+            - name: REDIS_URL
+              value: {{ .Values.redis_svc.url  }}
+            - name: MONGO_USER
+              value: {{ .Values.db.username }}
+            - name: MONGO_PASSWORD
+              value: {{ .Values.db.password }}
           command: ["/usr/local/bin/start-workers"]
       terminationGracePeriodSeconds: {{ .Values.worker.container.terminationGracePeriodSeconds }} # for long openstudio jobs. 
       volumes:

--- a/openstudio-server/templates/worker/worker-deploy.yaml
+++ b/openstudio-server/templates/worker/worker-deploy.yaml
@@ -40,6 +40,8 @@ spec:
               value: simulations
             - name:  COUNT
               value: "1"
+            - name: SECRET_KEY_BASE
+              value: {{ .Values.web.secret_key_value }}
           command: ["/usr/local/bin/start-workers"]
       terminationGracePeriodSeconds: {{ .Values.worker.container.terminationGracePeriodSeconds }} # for long openstudio jobs. 
       volumes:

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -19,12 +19,15 @@ nfs-server-provisioner:
     allowVolumeExpansion: false
     mountOptions:
       - vers=4 
+      - sync
 db:
   name:  "db"
   label: "db"
+  username: "openstudio"
+  password: "openstudio"
   container:
     name: "mongo-db"
-    image: "mongo:3.4.10"
+    image: "mongo:4.4.2"
     cpu: 2
     memory: "8Gi"
     ports:
@@ -62,18 +65,25 @@ nfs_pvc:
 redis:
   name: "redis"
   label: "redis"
+  password: "openstudio"
   container:
     name: "redis"
-    image: "redis:4.0.6"
+    image: "redis:6.0.9"
     cpu: 0.5
     memory: "1G"
     port: 6379
+  persistence:
+    enabled: true
+    storageClass: "ssd"
+    size: 5Gi
+    accessModes:
+      - "ReadWriteOnce"
 
 redis_svc:
   name: "queue"
   label: "redis"
   port: 6379
-
+  url: "redis://:openstudio@queue:6379"
 
 rserve:
   name: "rserve"
@@ -111,6 +121,15 @@ web:
      http: 80
      https: 443
 
+# For this to work and have more than 1 web pod we'll need to implement 
+# a distrbuted file locking scheme such a https://github.com/antirez/redlock-rbs 
+# as even with using NFS via sync it cannot guarantee file locking using mutliple clients
+web_hpa:
+  name: "web"
+  minReplicas: 1
+  maxReplicas: 1
+  targetCPUUtilizationPercentage: 50
+
 web_svc: 
   name: "web" 
   label: "web" 
@@ -130,7 +149,7 @@ worker:
       
 worker_hpa: 
   name: "worker"
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 20
   targetCPUUtilizationPercentage: 50
 

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -80,7 +80,7 @@ rserve:
   label: "rserve" 
   container:
     name: "rserve"
-    image: "nrel/openstudio-rserve:3.1.0"
+    image: "nrel/openstudio-rserve:3.2.0-rc1"
     cpu: 1
     memory: 2Gi
     
@@ -94,16 +94,17 @@ web_background:
   label: "web-background" 
   container:
     name: "web-background" 
-    image: "nrel/openstudio-server:3.1.0" 
+    image: "nrel/openstudio-server:3.2.0-rc1" 
     cpu: 1
     memory: "3Gi"
 
 web:
   name: "web"
   label: "web"
+  secret_key_value: "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
   container:
     name: "web"
-    image: "nrel/openstudio-server:3.1.0"
+    image: "nrel/openstudio-server:3.2.0-rc1"
     cpu: 2
     memory: "6Gi"
     port:
@@ -122,7 +123,7 @@ worker:
   label: "worker" 
   container:
     name: "worker"
-    image: "nrel/openstudio-server:3.1.0"
+    image: "nrel/openstudio-server:3.2.0-rc1"
     cpu: 1
     memory: "3Gi"
     terminationGracePeriodSeconds: 3600


### PR DESCRIPTION
Includes #14 

Updates OpenStudio-sever to use 3.2.0-rc1. Updates Mongo and Redis and allows password authentication. 
Redis now has persistent storage.  

