### PR TITLE
enable replicas for web-background for parrell project processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cluster.name | Kubernetes AWS or Google cluster name. If you change the default 
 worker_hpa.minReplicas | Worker pods that run the simulations | 1 |
 worker_hpa.maxReplicas | Maximum Worker pods that run the simulations | 20 |
 worker_hpa.targetCPUUtilizationPercentage | When aggregate CPU % of worker pods exceed threshold begin scaling. | 50 |
+web_background.replicas  | Number of projects/analyses to run in parrell. | 2 |
 web_background.container.image  | Container to run the web background. Can use a custom image to override default | nrel/openstudio-server:3.2.1 |
 web.container.image   | Container to run the web front-end. Can use a custom image to override default | nrel/openstudio-server:3.2.1 |
 worker.container.image   | Container to run the worker. Can use a custom image to override default | nrel/openstudio-server:3.2.1 |

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{  .Values.web_background.name  }}
 spec:
-  replicas: 1
+  replicas: {{  .Values.web_background.replicas  }}
   selector:
     matchLabels:
       app: {{  .Values.web_background.name  }}

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -102,11 +102,12 @@ rserve_svc:
 web_background: 
   name: "web-background"
   label: "web-background" 
+  replicas: 2
   container:
     name: "web-background" 
     image: "nrel/openstudio-server:3.2.1" 
-    cpu: 1
-    memory: "3Gi"
+    cpu: 0.5
+    memory: "1Gi"
 
 web:
   name: "web"


### PR DESCRIPTION
resolves #23 

It turns out this feature request is actually more of a helm/k8s deployment issue than the original issue filed here:  NREL/OpenStudio-server#618

The [web-background pod](https://github.com/NREL/openstudio-server-helm/blob/develop/openstudio-server/templates/web-background/web-background-deploy.yaml) spawns a resque worker that services the background and analyses queues. When a user submits a job to openstudio-server (e.g. cli command below), this action creates a new job which in turn gets put into the analysis resque queue.   Then, when the web-background receives a queue message and processes it, it loops through all the data points associated for that analysis and adds these to the simulation queue for processing by the worker nodes.  It waits for all of those simulations to complete before closing the analysis job and then begins processes the next analysis in the queue.  

Conceptually, it looks like this.  

![Server_resque](https://user-images.githubusercontent.com/7087120/124996262-e1a3d180-e005-11eb-979d-27a3ea793fec.png)


Currently, there is only one resque worker that services the analyses queue, which results in one analysis being ran at a time. By increasing the number of web-background k8s pods, you can increase the number of resque analyses jobs which translates into parallel analysis processing. This is especially useful when you have a lot of idle workers (e.g. close to the end of a large batch run and waiting on a few long running data points). This will maximize cpu usage on worker nodes and should reduce costs by avoiding idle resources. 

This PR makes the default of 2 web-background workers and reduces the cpu and memory as the jobs are not computational or memory intensive. 

The simulations queue is actually first-in-first-out, so openstudio-server will process stimulations based on the time they were submitted, but if there are available workers and no jobs are left in that analysis queue, it'll begin servicing the next analysis' data points.

Currently, PAT only supports one job at a time but you can submit multiple analyses uses the cli command as show below. 

`openstudio_meta" run_analysis   --ruby-lib-path="/Applications/ParametricAnalysisTool-3.2.1/ParametricAnalysisTool.app/Contents/Resources/OpenStudio/Ruby" "/Users/tcoleman/git/OpenStudio-PAT/sample_projects/Office_HVAC/Office_HVAC.json" "http://a02d1056e36dd4598bb372de92ce27c0-224809964.us-west-2.elb.amazonaws.com"`

`openstudio_meta" run_analysis   --ruby-lib-path="/Applications/ParametricAnalysisTool-3.2.1/ParametricAnalysisTool.app/Contents/Resources/OpenStudio/Ruby" "/Users/tcoleman/git/OpenStudio-PAT/sample_projects/Office_HVAC/Office_HVAC.json" "http://a02d1056e36dd4598bb372de92ce27c0-224809964.us-west-2.elb.amazonaws.com"`


