### PR TITLE
Fix default value for OS_SERVER_NUMBER_OF_WORKERS

### DIFF
--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -33,11 +33,10 @@ spec:
             - name: osdata
               mountPath: "/mnt/openstudio"
           env:
-            - name: OS_SERVER_NUMBER_OF_WORKERS
-              value: {{ .Values.rserve.number_of_workers }}
-          env:
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
+            - name: OS_SERVER_NUMBER_OF_WORKERS
+              value: {{ .Values.rserve.number_of_workers | quote }}
           livenessProbe:
             exec:
               command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]

--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -33,6 +33,9 @@ spec:
             - name: osdata
               mountPath: "/mnt/openstudio"
           env:
+            - name: OS_SERVER_NUMBER_OF_WORKERS
+              value: {{ .Values.rserve.number_of_workers }}
+          env:
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
           livenessProbe:

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -35,7 +35,7 @@ spec:
               mountPath: "/mnt/openstudio"
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
-              value: ${OS_SERVER_NUMBER_OF_WORKERS}
+              value: {{ .Values.rserve.number_of_workers }}
             - name: QUEUES
               value: background,analyses
             - name: SECRET_KEY_BASE

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -35,7 +35,7 @@ spec:
               mountPath: "/mnt/openstudio"
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
-              value: {{ .Values.rserve.number_of_workers }}
+              value: {{ .Values.rserve.number_of_workers | quote }}
             - name: QUEUES
               value: background,analyses
             - name: SECRET_KEY_BASE

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -38,7 +38,7 @@ spec:
               mountPath: "/mnt/openstudio"
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
-              value: {{ .Values.rserve.number_of_workers }}
+              value: {{ .Values.rserve.number_of_workers | quote }}
             - name: QUEUES
               value: analysis_wrappers
             - name: SECRET_KEY_BASE

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -38,7 +38,7 @@ spec:
               mountPath: "/mnt/openstudio"
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
-              value: ${OS_SERVER_NUMBER_OF_WORKERS}
+              value: {{ .Values.rserve.number_of_workers }}
             - name: QUEUES
               value: analysis_wrappers
             - name: SECRET_KEY_BASE

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -98,7 +98,7 @@ redis_svc:
 rserve:
   name: "rserve"
   label: "rserve" 
-  number_of_workers: 7
+  number_of_workers: "7"
   container:
     name: "rserve"
     image: "nrel/openstudio-rserve:3.3.0"

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -98,6 +98,7 @@ redis_svc:
 rserve:
   name: "rserve"
   label: "rserve" 
+  number_of_workers: 7
   container:
     name: "rserve"
     image: "nrel/openstudio-rserve:3.3.0"


### PR DESCRIPTION
Set a default value of OS_SERVER_NUMBER_OF_WORKERS to 7 for rserver to run when this is not set in the osa file. 