### PR TITLE
Updating for 3.5.0 OpenStudio-server release

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ worker_hpa.minReplicas | Worker pods that run the simulations | 1 |
 worker_hpa.maxReplicas | Maximum Worker pods that run the simulations | 20 |
 worker_hpa.targetCPUUtilizationPercentage | When aggregate CPU % of worker pods exceed threshold begin scaling. | 50 |
 web_background.replicas  | Number of projects/analyses to run in parallel. __*Note__ Algorithmic runs are currently not supported to run in parallel. Keep default value of 1 for these types of analyses.  | 1 |
-web_background.container.image  | Container to run the web background. Can use a custom image to override default | nrel/openstudio-server:3.4.0 |
-web.container.image   | Container to run the web front-end. Can use a custom image to override default | nrel/openstudio-server::3.4.0 |
-worker.container.image   | Container to run the worker. Can use a custom image to override default | nrel/openstudio-server::3.4.0 |
-rserve.container.image   | Container to run r server. Can use a custom image to override default | nrel/openstudio-rserve::3.4.0 |
+web_background.container.image  | Container to run the web background. Can use a custom image to override default | nrel/openstudio-server:3.5.0 |
+web.container.image   | Container to run the web front-end. Can use a custom image to override default | nrel/openstudio-server::3.5.0 |
+worker.container.image   | Container to run the worker. Can use a custom image to override default | nrel/openstudio-server::3.5.0 |
+rserve.container.image   | Container to run r server. Can use a custom image to override default | nrel/openstudio-rserve::3.5.0 |
 
 
 ## Accessing OpenStudio Server

--- a/openstudio-server/Chart.yaml
+++ b/openstudio-server/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.4.0-rc1
+appVersion: 3.5.0
 
 # This is an offical helm chart: https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner
 # openstudio-sever modfied this slighly to use deployment vs stateful sets as helm does not automatically 

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -101,7 +101,7 @@ rserve:
   number_of_workers: "1"
   container:
     name: "rserve"
-    image: "nrel/openstudio-rserve:3.4.0"
+    image: "nrel/openstudio-rserve:3.5.0"
     resources:
       requests:
         cpu: 1
@@ -118,7 +118,7 @@ web_background:
   replicas: 1
   container:
     name: "web-background" 
-    image: "nrel/openstudio-server:3.4.0" 
+    image: "nrel/openstudio-server:3.5.0" 
     resources:
       limits:
         cpu: 0.5
@@ -133,7 +133,7 @@ web:
   secret_key_value: "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
   container:
     name: "web"
-    image: "nrel/openstudio-server:3.4.0"
+    image: "nrel/openstudio-server:3.5.0"
     resources:
       limits:
         cpu: 2
@@ -166,7 +166,7 @@ worker:
   label: "worker" 
   container:
     name: "worker"
-    image: "nrel/openstudio-server:3.4.0"
+    image: "nrel/openstudio-server:3.5.0"
     resources:
       limits:
         cpu: 1


### PR DESCRIPTION
 OpenStudio-server v3.5.0 server is out. Updating helm chart. 