### PR TITLE
Additional Documentation for Large Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 This helm chart installs a OpenStudio-server instance (https://github.com/NREL/OpenStudio-server/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 You can interface with the OpenStudio-server cluster using the [Parametric Analysis Tool](https://github.com/NREL/OpenStudio-PAT), which is part of the OpenStudio collection of software tools.
 
+Note that this repository has both information for small and large workloads in the cloud. Refer to the Large Workload section below and in the [aws README](/aws/README.md).
+
 ## Prerequisites
 
-- Kubernetes 1.29+ cluster. Please refer to cluster setup instructions for [google](/google/README.md) or [aws](/aws/README.md) for information on how to provision a cluster.
+- Kubernetes 1.27+ cluster. Please refer to cluster setup instructions for [google](/google/README.md) or [aws](/aws/README.md) for information on how to provision a cluster.
 - [helm client](https://helm.sh/docs/intro/install/) (v3.12.0 or higher)
 - [kubectl client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (v1.27.0 or higher)
 

--- a/README.md
+++ b/README.md
@@ -71,20 +71,22 @@ helm install openstudio-server ./openstudio-server --set provider.name=azure --s
 
 Parameter | Description | Default
 --------- | ----------- | -------
-nfs-server-provisioner.persistence.size | Size of the volume for storing the data point results | 200Gi |
+nfs-server-provisioner.persistence.size | Size of the volume for storing the data point results | 550Gi |
 db.persistence.size | Size of the volume for MongoDB | 200Gi |
 cluster.name | Kubernetes AWS or Google cluster name. If you change the default name you need to set this name here otherwise AWS auto-scaling will not work correctly | openstudio-server |
-worker_hpa.minReplicas | Worker pods that run the simulations | 1 |
+worker_hpa.minReplicas | Worker pods that run the simulations | 2 |
 worker_hpa.maxReplicas | Maximum Worker pods that run the simulations | 20 |
 worker_hpa.targetCPUUtilizationPercentage | When aggregate CPU % of worker pods exceed threshold begin scaling. | 50 |
 web_background.replicas  | Number of projects/analyses to run in parallel. __*Note__ Algorithmic runs are currently not supported to run in parallel. Keep default value of 1 for these types of analyses.  | 1 |
-web_background.container.image  | Container to run the web background. Can use a custom image to override default | nrel/openstudio-server:3.6.0 |
-web.container.image   | Container to run the web front-end. Can use a custom image to override default | nrel/openstudio-server::3.6.0 |
-worker.container.image   | Container to run the worker. Can use a custom image to override default | nrel/openstudio-server::3.6.0 |
-rserve.container.image   | Container to run r server. Can use a custom image to override default | nrel/openstudio-rserve::3.6.0 |
+web_background.container.image  | Container to run the web background. Can use a custom image to override default | nrel/openstudio-server:3.7.0 |
+web.container.image   | Container to run the web front-end. Can use a custom image to override default | nrel/openstudio-server:3.7.0 |
+worker.container.image   | Container to run the worker. Can use a custom image to override default | nrel/openstudio-server:3.7.0 |
+rserve.container.image   | Container to run r server. Can use a custom image to override default | nrel/openstudio-rserve:3.7.0 |
 
 #### For Large Workloads
-Copy the text from inside the file `\openstudio-server\values_large.templateyaml` and paste it inside of `\openstudio-server\values.yaml`. Do this before using the `helm install ...` command.
+Copy the text from inside the [large template values file](/openstudio-server/values_large.templateyaml)] and paste it inside of the [values file](/openstudio-server/values.yaml). Do this before using the `helm install ...` command.
+
+Additionally, note that with large workloads you may have issues with downloading container images from Docker Hub if you have a lot of worker nodes. Therefore, you may want to upload the container images into the cloud's container registry and then update the container image path in the [values file](/openstudio-server/values.yaml). This [article](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html#:~:text=Identify%20the%20local%20image%20to,container%20images%20on%20your%20system.&text=You%20can%20identify%20an%20image,tag%20name%20combination%20to%20use.) has instructions on how to do this for aws' Elastic Container Registry (ECR).
 
 ## Accessing OpenStudio Server
 

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -169,7 +169,7 @@ worker_hpa:
   name: "worker"
   minReplicas: 2
   maxReplicas: 20
-  targetCPUUtilizationPercentage: 12
+  targetCPUUtilizationPercentage: 50
   stabilizationWindowSeconds: 3600
 
 

--- a/openstudio-server/values_large.templateyaml
+++ b/openstudio-server/values_large.templateyaml
@@ -170,7 +170,7 @@ worker_hpa:
   name: "worker"
   minReplicas: 2
   maxReplicas: 3800
-  targetCPUUtilizationPercentage: 12
+  targetCPUUtilizationPercentage: 50
   stabilizationWindowSeconds: 3600
 
 

--- a/openstudio-server/values_small.templateyaml
+++ b/openstudio-server/values_small.templateyaml
@@ -170,7 +170,7 @@ worker_hpa:
   name: "worker"
   minReplicas: 2
   maxReplicas: 20
-  targetCPUUtilizationPercentage: 12
+  targetCPUUtilizationPercentage: 50
   stabilizationWindowSeconds: 3600
 
 


### PR DESCRIPTION
This PR adds the following additional information:

- Added a note to the top of the readme highlighting the fact that instructions for large workloads are included.
- Lowered the minimum Kubernetes version down to 1.27+.
- Revised the default values listed in the readme to match the latest small values template.
- Added a suggestion to use the cloud's container registry instead of Docker Hub for very large workloads.
- Set the target CPU utilization back to 50%. The reason for setting it to 12% isn't applicable anymore.