### PR TITLE
feat: add option for loadbalancer to be internal

### DIFF
--- a/openstudio-server/templates/loadbalancer/loadbalancer.yaml
+++ b/openstudio-server/templates/loadbalancer/loadbalancer.yaml
@@ -2,9 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.load_balancer.name  }}
+  annotations:
+{{- if and (eq .Values.provider.name "aws") .Values.load_balancer.internal }}
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+{{- else if and (eq .Values.provider.name "azure") .Values.load_balancer.internal }}
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+{{- else if and (eq .Values.provider.name "google") .Values.load_balancer.internal }}
+    cloud.google.com/load-balancer-type: "Internal"
+{{- end }}
 spec:
   type: LoadBalancer
-  externalTrafficPolicy:  {{ .Values.load_balancer.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.load_balancer.externalTrafficPolicy }}
   selector:
     app: {{ .Values.load_balancer.label }}
     release: {{ .Release.Name }}

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -45,6 +45,7 @@ load_balancer:
   name: "ingress-load-balancer"
   externalTrafficPolicy: "Local"
   label: "web"
+  internal: false
   ports:
     http_name: "http"
     http_port: 80

--- a/openstudio-server/values_large.templateyaml
+++ b/openstudio-server/values_large.templateyaml
@@ -45,6 +45,7 @@ load_balancer:
   name: "ingress-load-balancer"
   externalTrafficPolicy: "Local"
   label: "web"
+  internal: false
   ports:
     http_name: "http"
     http_port: 80

--- a/openstudio-server/values_small.templateyaml
+++ b/openstudio-server/values_small.templateyaml
@@ -45,6 +45,7 @@ load_balancer:
   name: "ingress-load-balancer"
   externalTrafficPolicy: "Local"
   label: "web"
+  internal: false
   ports:
     http_name: "http"
     http_port: 80


### PR DESCRIPTION
This PR introduces the ability to configure the OpenStudio load balancer as an **internal load balancer** for scenarios where the service needs to be accessible only within a private network. This change is **backward compatible**, as the new behavior is disabled by default (`load_balancer.internal: false`).