### PR TITLE
feat: introduce backward-compatible multi-tenancy support

### DIFF
--- a/openstudio-server/templates/priority-class/priority_high.yaml
+++ b/openstudio-server/templates/priority-class/priority_high.yaml
@@ -1,3 +1,4 @@
+{{- if not (lookup "scheduling.k8s.io/v1" "PriorityClass" "" "high-priority") }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 1000000
 globalDefault: false
 description: "Used for core rails web service pods only."
+{{- end }}

--- a/openstudio-server/templates/priority-class/priority_low.yaml
+++ b/openstudio-server/templates/priority-class/priority_low.yaml
@@ -1,3 +1,4 @@
+{{- if not (lookup "scheduling.k8s.io/v1" "PriorityClass" "" "high-priority") }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 10000
 globalDefault: true
 description: "Used for non-core service pods only. This is default"
+{{- end }}

--- a/openstudio-server/templates/service-account/nfs-disconnect-rbac.yaml
+++ b/openstudio-server/templates/service-account/nfs-disconnect-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "fabric8-rbac") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/openstudio-server/templates/storageclass/storageclass.yaml
+++ b/openstudio-server/templates/storageclass/storageclass.yaml
@@ -1,3 +1,4 @@
+{{- if not (lookup "storage.k8s.io/v1" "StorageClass" "" "ssd") }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -27,3 +28,4 @@ allowedTopologies:
   - key: nodegroup
     values:
       - web-group
+{{- end }}


### PR DESCRIPTION
This PR introduces **multi-tenancy support** for the OpenStudio Helm chart. The primary motivation for this enhancement is to enable a single Kubernetes cluster to run multiple OpenStudio instances with different versions, tailored for specific use cases.