### PR TITLE
Revised helm chart to work with Azure AKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,12 @@ Once the cluster is up and running, you can use `kubectl` to determine the exter
 AWS is the long domain (a0a4014d98f0211ea91cb06528280f48-1900622776.us-west-2.elb.amazonaws.com)
 
 ```bash
-$ kubectl get svc ingress-load-balancer
+kubectl get svc ingress-load-balancer
+```
+
+example output:
+
+```bash
 NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP                                                               PORT(S)                      AGE
 ingress-load-balancer   LoadBalancer   10.100.246.21   a52e7c2e22f3940a8aa9d80b5220d468-1479205808.us-east-1.elb.amazonaws.com   80:32739/TCP,443:31344/TCP   5m56s
 ```
@@ -151,7 +156,12 @@ ingress-load-balancer   LoadBalancer   10.100.246.21   a52e7c2e22f3940a8aa9d80b5
 Google is 35.247.75.9
 
 ```bash
-$ kubectl get svc ingress-load-balancer
+kubectl get svc ingress-load-balancer
+```
+
+example output:
+
+```bash
 NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
 ingress-load-balancer   LoadBalancer   10.55.246.197   35.247.75.9   80:32613/TCP,443:31562/TCP   35m
 ```
@@ -159,7 +169,12 @@ ingress-load-balancer   LoadBalancer   10.55.246.197   35.247.75.9   80:32613/TC
 Azure is 20.190.10.17
 
 ```bash
-$ kubectl get svc ingress-load-balancer
+kubectl get svc ingress-load-balancer
+```
+
+example output:
+
+```bash
 NAME                                       TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)  AGE
 ingress-load-balancer                      LoadBalancer   10.0.248.18   20.190.10.17   80:31879/TCP 443:30780/TCP 3m53s
 ```

--- a/aks_config.bicep
+++ b/aks_config.bicep
@@ -1,0 +1,56 @@
+@description('The name of the Managed Cluster resource.')
+param clusterName string = 'openstudio-server'
+
+@description('The location of the Managed Cluster resource.')
+param location string = resourceGroup().location
+
+@description('The size of the Virtual Machine.')
+param agentVMSize string = 'd4ps_v6'
+
+@description('The Kubernetes version of the Managed Cluster resource.')
+param kubernetesVersion string = '1.29'
+
+@description('DNS prefix for the public DNS name of the cluster.')
+param dnsPrefix string = '${clusterName}${uniqueString(resourceGroup().id)}'
+
+// Revise vm and count etc. to match eks config files
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-02-01' = {
+  name: clusterName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    kubernetesVersion: kubernetesVersion
+    dnsPrefix: dnsPrefix
+    agentPoolProfiles: [
+      {
+        name: 'webgroup'
+        osDiskSizeGB: 550
+        count: 2
+        vmSize: agentVMSize
+        osType: 'Linux'
+        nodeLabels: {
+          nodegroup: 'web-group'
+        }
+        mode: 'System'
+      }
+      {
+        name: 'workergroup'
+        osDiskSizeGB: 400
+        count: 1
+        vmSize: agentVMSize
+        osType: 'Linux'
+        nodeLabels: {
+          nodegroup: 'worker-group'
+        }
+        enableAutoScaling: true
+        minCount: 0
+        maxCount: 6
+        mode: 'User'
+      }
+    ]
+  }
+}
+
+output controlPlaneFQDN string = aksCluster.properties.fqdn

--- a/azure/README.md
+++ b/azure/README.md
@@ -9,6 +9,14 @@ Below is a guide to help setup a Microsoft Azure Kubernetes Cluster (AKS) using 
 
 https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
+## Define environment variables
+
+```bash
+export MY_RESOURCE_GROUP_NAME="openstudio-server"
+export REGION="westus2"
+export MY_AKS_CLUSTER_NAME="openstudio-server"
+```
+
 ## Use az to login to your account.
 
 ```bash
@@ -22,27 +30,31 @@ This will allow you to login to your Azure account. If your using only a termina
 Create a resource group and specifiy a data center location. The example below uses westus2 region.
 
 ```bash
-az group create --name openstudio-server --location westus2
+az group create --name $MY_RESOURCE_GROUP_NAME --location $REGION
 ```
 
-## Create the cluster. Change the --max-count and --node-vm-size to your use case.
+## Create the cluster. This example will create a cluster with 2 nodes of instance type Standard_DS2_v2 with max nodes = 6. This cluster is set to autoscale up to this max node amount. Vary the kubernetes version to your needs.
 
 ```bash
-az aks create --resource-group openstudio-server \
-    --name openstudio-server \
-    --kubernetes-version 1.18.14 \
-    --node-count 3 \
-    --node-vm-size Standard_D4_v4 \
-    --enable-cluster-autoscaler \
-    --min-count 3 \
-    --max-count 8 \
-    --ssh-key-value  ~/.ssh/id_rsa.pub
+az deployment group create \
+  --resource-group $MY_RESOURCE_GROUP_NAME \
+  --template-file aks_config.bicep \
+  --parameters clusterName=$MY_AKS_CLUSTER_NAME kubernetesVersion=1.29 \
+```
+
+## For large scale analysis, create the cluster using these parameters.
+
+```bash
+az deployment group create \
+  --resource-group $MY_RESOURCE_GROUP_NAME \
+  --template-file aks_config.bicep \
+  --parameters clusterName=$MY_AKS_CLUSTER_NAME agentVMSize=D32ps_v6 kubernetesVersion=1.29 \
 ```
 
 ## Set credentials to use cluster.
 
 ```bash
-az aks get-credentials --resource-group openstudio-server --name openstudio-server
+az aks get-credentials --resource-group $MY_RESOURCE_GROUP_NAME --name $MY_AKS_CLUSTER_NAME
 ```
 
 The above command creates the config in ~/.kube/config which is needed to use the `kubectl` cli to interface with the cluster. Once this is ran, confirm that you are connected and able to interface with the cluster by running the following.

--- a/openstudio-server/templates/autoscaler/cluster-autoscaler-autodiscover.yaml
+++ b/openstudio-server/templates/autoscaler/cluster-autoscaler-autodiscover.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Values.provider.name "aws" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -158,14 +157,11 @@ spec:
             requests:
               cpu: 1000m
               memory: 2Gi
-          env:
-            - name: AWS_REGION
-              value: us-west-2
           command:
             - ./cluster-autoscaler
             - --v=4
             - --stderrthreshold=info
-            - --cloud-provider=aws
+            - --cloud-provider={{ .Values.provider.name }}
             - --skip-nodes-with-local-storage=false
             - --expander=least-waste
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.cluster.name }}
@@ -179,4 +175,3 @@ spec:
         - name: ssl-certs
           hostPath:
             path: "/etc/ssl/certs/ca-bundle.crt"
-{{ end }}


### PR DESCRIPTION
Previously, the recent changes made to the helm chart for the AWS use case broke the application for non-AWS providers such as Azure. This change creates two node pools in AKS (web-group and worker-group). This change allows the helm chart to function correctly. Additionally, the Azure readme file was updated to indicate the new process for creating the cluster which now uses a bicep file. It's similar to the EKS config file used for setting up the kubernetes cluster in AWS' EKS.

#61 