### PR TITLE
feat(chart): add per-workload service accounts and least-privilege RBAC

### DIFF
--- a/aws/cluster_setup.md
+++ b/aws/cluster_setup.md
@@ -1,0 +1,445 @@
+# AWS EKS Setup: Spot Workers and On-Demand Essential Pods
+
+This guide documents how to create an EKS cluster where:
+
+- Essential OpenStudio Server pods run on regular (on-demand) instances.
+- Worker pods run on spot instances.
+- Required EKS add-ons are installed during initial setup: Amazon EBS CSI Driver, Amazon VPC CNI, and kube-proxy.
+
+This configuration is intended for large workloads where you want lower worker cost while keeping core services stable for NFS-backed workflows.
+
+## 1. Prerequisites
+
+- AWS account permissions for EKS, EC2, IAM, and CloudFormation
+- `aws` CLI configured (`aws configure`)
+- `eksctl` v1.40.0+
+- `kubectl` compatible with your target cluster version
+- `helm` v3.12+
+
+Optional but recommended before large clusters:
+
+- Request EC2 quota increases for both On-Demand and Spot instance families you plan to use.
+
+### 1.1 Quota sizing for 10,000 worker pods
+
+For AWS, the key EC2 quota for the worker node groups in this guide is:
+
+- `All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests` (regional, in vCPUs)
+
+If your worker pod request is `800m` (as used in the large workload template), the minimum worker compute is:
+
+- Required worker vCPU = `10,000 pods * 800m` = `8,000 vCPU`
+
+Using the worker instance types in this repo (for example `c7i.48xlarge` / `c7a.48xlarge` at 192 vCPU each):
+
+- Minimum spot nodes = `ceil(8,000 / 192)` = `42 nodes`
+
+You should add headroom for:
+
+- Kubernetes/system daemons
+- Spot interruption replacement
+- Bin-packing inefficiency during scale transitions
+
+Recommended request target (20% headroom):
+
+- Spot vCPU quota target = `8,000 * 1.2` = `9,600 vCPU`
+- Spot node target at 192 vCPU/node = `ceil(9,600 / 192)` = `50 nodes`
+
+On-demand quota for essential services depends on web-group sizing. With two `m7i.8xlarge` essential nodes:
+
+- On-demand vCPU = `32 vCPU`
+
+Recommended on-demand target with failover/headroom:
+
+- `64 vCPU` (2 x `m7i.8xlarge`) minimum practical target
+- `96 vCPU` if you want more maintenance/failure margin
+
+If you tune worker CPU requests, use this formula:
+
+- Spot vCPU quota target = `worker_pod_count * worker_cpu_request * headroom_factor`
+
+Example with `800m` workers and 20% headroom:
+
+- `10,000 * 0.8 * 1.2 = 9,600 vCPU`
+
+Important: quota alone is not enough at this scale. You must also ensure subnet IP capacity for VPC CNI (or enable prefix delegation) so nodes can host the required pod density.
+
+## 2. Recommended Node Group Pattern
+
+Use separate managed node groups and labels:
+
+- On-demand node group for essential pods: label `nodegroup=web-group`
+- Spot node groups for workers: label `nodegroup=worker-group`
+
+The chart templates in this repo already use node affinity for this pattern:
+
+- Essential services (web, db, redis, rserve, web-background, autoscaler, nfs provisioner) target `web-group`.
+- Worker deployment targets `worker-group`.
+
+## 3. Cluster Config Requirements (eksctl)
+
+Use [eks_config_large-spot.yaml](../eks_config_large-spot.yaml) as your base. Keep [eks_config_large-spot-workerng.yaml](../eks_config_large-spot-workerng.yaml) and [worker_node_group_large-spot.yaml](../worker_node_group_large-spot.yaml) aligned on worker capacity if you use those variants. Ensure these key settings are present.
+
+### 3.1 OIDC and EBS CSI IAM setup
+
+```yaml
+iam:
+  withOIDC: true
+  serviceAccounts:
+    - metadata:
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+      wellKnownPolicies:
+        ebsCSIController: true
+```
+
+For S3 exporter IRSA, create an additional IAM policy and role with at least:
+
+- `s3:ListBucket` on your bucket
+- `s3:GetObject` and `s3:PutObject` on your export prefix
+
+Then annotate the chart's exporter service account by setting:
+
+```bash
+--set s3_exporter.enabled=true \
+--set s3_exporter.bucket=<your-bucket> \
+--set s3_exporter.prefix=<your-prefix> \
+--set s3_exporter.serviceAccount.roleArn=arn:aws:iam::<account-id>:role/<s3-exporter-role>
+```
+
+### 3.2 On-demand essential node group
+
+```yaml
+managedNodeGroups:
+  - name: Web-node-group2
+    instanceType: m7i.8xlarge
+    minSize: 0
+    maxSize: 2
+    desiredCapacity: 2
+    labels:
+      nodegroup: web-group
+      role: essential
+    tags:
+      node-role: essential
+```
+
+### 3.3 Spot worker node groups
+
+```yaml
+managedNodeGroups:
+  - name: worker-node-group-spot-2a
+    spot: true
+    instanceTypes: ["c7i.48xlarge", "c7a.48xlarge", "c7i.metal-48xl", "c7a.metal-48xl"]
+    minSize: 0
+    maxSize: 20
+    desiredCapacity: 0
+    labels:
+      nodegroup: worker-group
+      role: worker
+    tags:
+      node-role: worker
+      capacity-type: spot
+```
+
+Repeat spot worker node groups across multiple subnets/AZs for availability.
+
+### 3.4 Subnet planning for ITS-provided subnets
+
+This cluster uses private subnets provided internally by the ITS organization.
+
+Key points:
+
+- You can assign multiple subnets to a node group.
+- ITS subnets are currently `/25`, which provides `126` usable IPs per subnet.
+- Smaller VM instance types can exhaust subnet IPs faster because you need more nodes to deliver the same total compute.
+- Larger instance types reduce node count and helped avoid IP exhaustion in prior runs.
+
+Operational guidance:
+
+- Spread worker node groups across multiple subnets (and AZs where possible).
+- Monitor subnet free IPs during scale tests before production runs.
+- If worker scale-out stalls, check subnet IP availability before assuming EC2 capacity shortage.
+
+Roadmap note:
+
+- ITS is working on enabling additional non-routable private IP space. Follow up with the AWS Status team for rollout timing.
+
+### 3.5 Required EKS add-ons at cluster creation
+
+Add this `addons` section (or verify it exists):
+
+```yaml
+addons:
+  - name: vpc-cni
+    mostRecent: true
+  - name: kube-proxy
+    mostRecent: true
+  - name: aws-ebs-csi-driver
+    wellKnownPolicies:
+      ebsCSIController: true
+```
+
+Note:
+
+- `vpc-cni` is required for pod networking/IP assignment.
+- `kube-proxy` is required for Kubernetes service networking.
+- `aws-ebs-csi-driver` is required for dynamic EBS-backed PVC provisioning used by the deployment.
+
+## 4. Create the Cluster
+
+From the repo root:
+
+```bash
+eksctl create cluster -f eks_config_large-spot.yaml
+```
+
+## 5. Verify Node Groups, Labels, and Capacity Type
+
+Check node groups:
+
+```bash
+eksctl get nodegroup --cluster openstudio-server-03 --region us-west-2
+```
+
+Check node labels and spot vs on-demand capacity:
+
+```bash
+kubectl get nodes -L nodegroup,eks.amazonaws.com/capacityType
+```
+
+Expected result:
+
+- Essential node(s): `nodegroup=web-group`, typically `ON_DEMAND`
+- Worker node(s): `nodegroup=worker-group`, typically `SPOT`
+
+## 6. Verify Required Add-ons
+
+```bash
+aws eks describe-addon --cluster-name openstudio-server-03 --addon-name vpc-cni --region us-west-2 --query 'addon.status'
+aws eks describe-addon --cluster-name openstudio-server-03 --addon-name kube-proxy --region us-west-2 --query 'addon.status'
+aws eks describe-addon --cluster-name openstudio-server-03 --addon-name aws-ebs-csi-driver --region us-west-2 --query 'addon.status'
+```
+
+Each command should return `"ACTIVE"`.
+
+## 6.1 Cluster Autoscaler IAM for managed node groups
+
+If you deploy Cluster Autoscaler against EKS managed node groups, ensure the IAM role used by the autoscaler service account includes `eks:DescribeNodegroup`.
+
+Without this permission, autoscaler logs will show repeated `AccessDeniedException` for managed node groups, which can degrade scale decision quality.
+
+Minimum additional permission:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "eks:DescribeNodegroup"
+  ],
+  "Resource": "*"
+}
+```
+
+Quick verification:
+
+```bash
+kubectl -n kube-system logs deploy/cluster-autoscaler | grep -E "DescribeNodegroup|AccessDeniedException"
+```
+
+
+## 7. Operational Recommendations
+
+- Keep at least one on-demand essential node available (`desiredCapacity >= 1`) to avoid core service disruption.
+- Use multiple spot worker node groups across AZs/subnets for resilience and better spot capacity.
+- Keep `worker_hpa` aligned with max spot node capacity in your cluster config.
+
+## 8. Add Auto Scaling Launch Lifecycle Hooks (Optional)
+
+If you need a short pause during node launch (for warm-up checks or custom automation), add an Auto Scaling lifecycle hook to each worker node group ASG.
+
+Important notes:
+
+- EKS managed node groups own their ASGs. During updates or replacements, ASG names can change.
+- Re-check ASG names after node group updates and re-apply hooks if needed.
+- With `--default-result CONTINUE`, the instance launch proceeds even if no external process sends lifecycle completion.
+
+Get the ASG name for a managed node group:
+
+```bash
+aws eks describe-nodegroup \
+  --cluster-name openstudio-server-03 \
+  --nodegroup-name worker-node-group-spot-2c \
+  --region us-west-2 \
+  --profile developers-554977624503 \
+  --query 'nodegroup.resources.autoScalingGroups[0].name' \
+  --output text
+```
+
+Add the launch lifecycle hook (example):
+
+```bash
+aws autoscaling put-lifecycle-hook \
+  --lifecycle-hook-name Launch-LC-Hook \
+  --auto-scaling-group-name eks-worker-node-group-spot-02-56c8852f-5f77-b3c0-3a70-ede003827aaa \
+  --lifecycle-transition autoscaling:EC2_INSTANCE_LAUNCHING \
+  --role-arn arn:aws:iam::554977624503:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling \
+  --heartbeat-timeout 30 \
+  --default-result CONTINUE \
+  --profile developers-554977624503
+```
+
+Verify hooks on the ASG:
+
+```bash
+aws autoscaling describe-lifecycle-hooks \
+  --auto-scaling-group-name eks-worker-node-group-spot-02-56c8852f-5f77-b3c0-3a70-ede003827aaa \
+  --profile developers-554977624503
+```
+
+Repeat for each worker node group ASG you want to control.
+
+## 9. Example: Scale a Spot Worker Node Group
+
+Use `eksctl scale nodegroup` to quickly adjust a worker group.
+
+```bash
+eksctl scale nodegroup --cluster openstudio-server-03 --name worker-node-group-spot-2c --nodes 1 --nodes-max 9 --nodes-min 0 --region us-west-2 --profile developers-554977624503
+```
+
+What this does:
+
+- Sets desired nodes to `1`
+- Sets autoscaler floor to `0`
+- Sets autoscaler ceiling to `9`
+
+Verify the updated node group settings:
+
+```bash
+eksctl get nodegroup --cluster openstudio-server-03 --region us-west-2 --profile developers-554977624503
+```
+
+Verify worker nodes become available:
+
+```bash
+kubectl get nodes -L nodegroup,eks.amazonaws.com/capacityType
+```
+## 10. Deploy OpenStudio Server Chart
+
+```bash
+helm install openstudio-server ./openstudio-server --set provider.name=aws
+```
+
+### 10.1 Service account hardening rollout (default SA remediation)
+
+This chart now supports phased remediation for the GuardDuty finding about admin access on the namespace `default` ServiceAccount.
+
+Phase 1 (migration, keep legacy binding temporarily):
+
+```bash
+helm upgrade --install openstudio-server ./openstudio-server \
+  --set provider.name=aws \
+  --set security.legacyDefaultServiceAccountClusterAdmin.enabled=true
+```
+
+Phase 2 (remediation complete, remove default SA admin):
+
+```bash
+helm upgrade --install openstudio-server ./openstudio-server \
+  --set provider.name=aws \
+  --set security.legacyDefaultServiceAccountClusterAdmin.enabled=false
+```
+
+Validate no app workload is using `default` ServiceAccount:
+
+```bash
+kubectl get pods -n openstudio-server \
+  -o custom-columns=NAME:.metadata.name,SA:.spec.serviceAccountName
+```
+
+Validate no `cluster-admin` binding remains for ServiceAccount `default`:
+
+```bash
+kubectl get clusterrolebinding fabric8-rbac -o yaml
+```
+
+## 11. Verify Essential vs Worker Pod Placement
+
+```bash
+kubectl get pods -o wide
+```
+
+Confirm:
+
+- `web`, `web-background`, `db`, `redis`, `rserve`, and `nfs-server-provisioner` are on `web-group` nodes.
+- `worker-*` pods are on `worker-group` spot nodes.
+
+## 12. NFS and Storage Notes
+
+- NFS server and core services should remain on on-demand `web-group` nodes.
+- Worker interruption on Spot should not take down the core web/db/nfs path.
+- If PVC provisioning fails, verify EBS CSI add-on is `ACTIVE` and the IAM OIDC/service account setup is present.
+
+
+## 13. Scale worker pods
+
+When scaling worker capacity during active analyses, prefer patching the worker HPA rather than running `helm upgrade` for this specific change. This avoids unnecessary deployment churn while jobs are running.
+
+Example: set worker HPA max replicas to `200`.
+
+```bash
+kubectl patch hpa worker-hpa -n openstudio-server --type='json' -p='[{"op": "replace", "path": "/spec/maxReplicas", "value": 200}]'
+```
+
+You can also update the HPA minimum if needed:
+
+```bash
+kubectl patch hpa worker -n default --type='json' -p='[{"op": "replace", "path": "/spec/minReplicas", "value": 1}]'
+```
+
+Important note about max pods per node:
+
+- `maxPodsPerNode` is an EKS node group/launch configuration setting, not a Kubernetes resource you can patch with `kubectl`.
+- Plan this value in your node group configuration before provisioning or when updating/replacing the node group.
+- This matters at high scale because pod density per node and subnet IP limits both affect how far worker pods can scale.
+
+
+## 14. Tear down
+
+To remove everything, first remove the helm chart as this deletes resources used by helm/k8s such as persistent volumes. If you just remove the EKS cluster, these will remain and will be billed.
+
+helm delete openstudio-server ./openstudio-server --set provider.name=aws 
+
+Confirm deletion and check if all pods are removed 
+
+# show all
+kubectl get all --all-namespaces 
+# show the persistent volumes 
+kubectl get pv
+
+When you confirm openstudio-server 
+
+
+
+
+## 15. Troubleshooting and FAQ
+
+Many core Kubernetes services run as pods in the `kube-system` namespace. These are often the first place to check when node networking, scaling, or add-on behavior is not as expected.
+
+List all `kube-system` pods:
+
+```bash
+get pod -n kube-system --show-labels
+```
+
+Check logs for service using labels example:
+
+```bash
+kubectl get logs -l app=ebs-csi-controller, -n kube-system
+```
+
+Useful follow-up checks:
+
+```bash
+kubectl describe pod -n kube-system aws-node-csx9h
+aws eks describe-addon --cluster-name openstudio-server-03 --addon-name vpc-cni --region us-west-2 --query 'addon.status'
+```

--- a/openstudio-server/templates/db/db-deploy.yaml
+++ b/openstudio-server/templates/db/db-deploy.yaml
@@ -19,6 +19,7 @@ spec:
         app: {{ .Values.db.name }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.db.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -40,6 +41,11 @@ spec:
             requests:
               cpu:  {{  .Values.db.container.resources.requests.cpu  }}
               memory:  {{  .Values.db.container.resources.requests.memory  }}
+            {{- with .Values.db.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           env:
             - name: MONGO_INITDB_ROOT_USERNAME
               value: {{ .Values.db.username }}

--- a/openstudio-server/templates/hooks/pre-delete-hook.yaml
+++ b/openstudio-server/templates/hooks/pre-delete-hook.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nfs-client-cleanup
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "3"
@@ -12,6 +12,7 @@ spec:
     metadata:
       name: nfs-client-cleanup
     spec:
+      serviceAccountName: {{ .Values.pre_delete_hook.serviceAccount.name }}
       containers:
         - name: kubectl
           image: "k8s.gcr.io/hyperkube:v1.12.1"

--- a/openstudio-server/templates/redis/redis-deploy.yaml
+++ b/openstudio-server/templates/redis/redis-deploy.yaml
@@ -14,15 +14,18 @@ spec:
         app: {{ .Values.redis.name  }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.redis.serviceAccount.name }}
+      {{- if .Values.redis.affinity.enabled }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: nodegroup
+                  - key: {{ .Values.redis.affinity.nodegroupKey }}
                     operator: In
                     values:
-                      - web-group
+                      {{- toYaml .Values.redis.affinity.nodegroupValues | nindent 22 }}
+      {{- end }}
       containers:
         - name: {{ .Values.redis.container.name  }}
           image: {{ .Values.redis.container.image  }}
@@ -30,6 +33,11 @@ spec:
             requests:
               cpu:  {{  .Values.redis.container.resources.requests.cpu  }}
               memory:  {{  .Values.redis.container.resources.requests.memory  }}
+            {{- with .Values.redis.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.redis.container.port  }}
           volumeMounts:
@@ -39,5 +47,9 @@ spec:
       priorityClassName: high-priority
       volumes:
         - name: {{ .Values.redis.name }}
+          {{- if .Values.redis.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.redis.name }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -19,6 +19,7 @@ spec:
         app: {{ .Values.rserve.name }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.rserve.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,6 +29,35 @@ spec:
                     operator: In
                     values:
                       - web-group
+      initContainers:
+          - name: init-verify-mnt-openstudio
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Verifying /mnt/openstudio mount..."
+                if [ ! -d "/mnt/openstudio" ]; then
+                  echo "ERROR: /mnt/openstudio directory does not exist"
+                  exit 1
+                fi
+                echo "Checking mount point..."
+                if ! grep -qs "/mnt/openstudio " /proc/mounts; then
+                  echo "ERROR: /mnt/openstudio is not mounted"
+                  exit 1
+                fi
+                echo "Verifying write permissions..."
+                TEST_FILE="/mnt/openstudio/.startup-check-$(date +%s)"
+                if ! touch "$TEST_FILE" 2>/dev/null; then
+                  echo "ERROR: /mnt/openstudio is not writable"
+                  exit 1
+                fi
+                rm -f "$TEST_FILE"
+                echo "SUCCESS: /mnt/openstudio is mounted and writable"
+            volumeMounts:
+              - name: osdata
+                mountPath: "/mnt/openstudio"
       containers:
         - name: {{ .Values.rserve.container.name }}
           image: {{ .Values.rserve.container.image }}
@@ -35,6 +65,11 @@ spec:
             requests:
               cpu:  {{  .Values.rserve.container.resources.requests.cpu  }}
               memory:  {{  .Values.rserve.container.resources.requests.memory  }}
+            {{- with .Values.rserve.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           volumeMounts:
             - name: osdata
               mountPath: "/mnt/openstudio"
@@ -51,11 +86,17 @@ spec:
                value: {{ .Values.db.password }}
           livenessProbe:
             exec:
-              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
-            initialDelaySeconds: 5
-            periodSeconds: 30
-            timeoutSeconds: 30
-            failureThreshold: 3
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  grep -qs "/mnt/openstudio " /proc/mounts && \
+                  test -w /mnt/openstudio && \
+                  exit 0 || exit 1
+            initialDelaySeconds: {{ .Values.rserve.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.rserve.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.rserve.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.rserve.livenessProbe.failureThreshold }}
       priorityClassName: high-priority
       volumes:
         - name: osdata

--- a/openstudio-server/templates/service-account/nfs-disconnect-rbac.yaml
+++ b/openstudio-server/templates/service-account/nfs-disconnect-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.security.legacyDefaultServiceAccountClusterAdmin.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -5,8 +6,37 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nfs-client-cleanup
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      - {{ .Values.web.name }}
+      - {{ .Values.web_background.name }}
+      - {{ .Values.rserve.name }}
+    verbs: ["delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nfs-client-cleanup
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.pre_delete_hook.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: nfs-client-cleanup
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/openstudio-server/templates/service-account/workload-serviceaccounts.yaml
+++ b/openstudio-server/templates/service-account/workload-serviceaccounts.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.web.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.web.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.web.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.web_background.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.web_background.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.web_background.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.worker.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.worker.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.worker.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.rserve.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.rserve.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.rserve.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.db.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.db.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.db.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.redis.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.redis.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.redis.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.pre_delete_hook.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.pre_delete_hook.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.pre_delete_hook.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -3,7 +3,13 @@ kind: Deployment
 metadata:
   name: {{  .Values.web_background.name  }}
 spec:
-  replicas: {{  .Values.web_background.replicas  }}
+{{- if .Values.web_background_hpa.enabled }}
+  replicas: {{ .Values.web_background_hpa.minReplicas }}
+{{- else if .Values.web_background_keda.enabled }}
+  replicas: {{ .Values.web_background_keda.minReplicas }}
+{{- else }}
+  replicas: {{ .Values.web_background.replicas }}
+{{- end }}
   selector:
     matchLabels:
       app: {{  .Values.web_background.name  }}
@@ -19,6 +25,8 @@ spec:
         app: {{  .Values.web_background.name  }}
         release: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.web_background.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ .Values.web_background.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,6 +36,47 @@ spec:
                     operator: In
                     values:
                       - web-group
+      initContainers:
+          - name: init-verify-mnt-openstudio
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Verifying /mnt/openstudio mount..."
+                if [ ! -d "/mnt/openstudio" ]; then
+                  echo "ERROR: /mnt/openstudio directory does not exist"
+                  exit 1
+                fi
+                echo "Checking mount point..."
+                if ! grep -qs "/mnt/openstudio " /proc/mounts; then
+                  echo "ERROR: /mnt/openstudio is not mounted"
+                  exit 1
+                fi
+                echo "Verifying write permissions..."
+                TEST_FILE="/mnt/openstudio/.startup-check-$(date +%s)"
+                if ! touch "$TEST_FILE" 2>/dev/null; then
+                  echo "ERROR: /mnt/openstudio is not writable"
+                  exit 1
+                fi
+                rm -f "$TEST_FILE"
+                echo "SUCCESS: /mnt/openstudio is mounted and writable"
+            volumeMounts:
+              - name: nfs
+                mountPath: "/mnt/openstudio"
+          - name: init-nginx-config
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                echo "Injecting Nginx configuration with gzip enabled..."
+                cp /etc/nginx-config/nginx.conf /opt/nginx/conf/nginx.conf
+                echo "Nginx configuration injected successfully"
+            volumeMounts:
+              - name: nginx-config
+                mountPath: /etc/nginx-config
       containers:
         - name:  {{  .Values.web_background.container.name  }}
           image:  {{  .Values.web_background.container.image  }}
@@ -36,32 +85,78 @@ spec:
             requests:
               cpu:  {{  .Values.web_background.container.resources.requests.cpu  }}
               memory:  {{  .Values.web_background.container.resources.requests.memory  }}
+            {{- with .Values.web_background.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           volumeMounts:
             - name: nfs
               mountPath: "/mnt/openstudio"
+            {{- if .Values.server_hotfix.enabled }}
+            - name: server-hotfix-scripts
+              mountPath: /opt/hotfix
+              readOnly: true
+            {{- end }}
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
               value: {{ .Values.rserve.number_of_workers | quote }}
             - name: QUEUES
-              value: background,analyses
+              value: {{ .Values.web_background.queues | quote }}
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
             - name: REDIS_URL
               value: {{ .Values.redis_svc.url  }}
+{{- if .Values.web_background_keda.enabled }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.redis.password }}
+{{- end }}
             - name: MONGO_USER
               value: {{ .Values.db.username }}
             - name: MONGO_PASSWORD
               value: {{ .Values.db.password }}
-          command: ["/usr/local/bin/start-web-background"]
+            - name: OS_SERVER_HOTFIX_ENFORCE_BATCH_RUN_START
+              value: {{ .Values.server_hotfix.enforceBatchRunStart | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_ENABLED
+              value: {{ .Values.server_hotfix.completedKeyTtlEnabled | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_SECONDS
+              value: {{ .Values.server_hotfix.completedKeyTtlSeconds | quote }}
+            - name: OS_SERVER_HOTFIX_AUTOCHAIN_LHS_TO_BATCH_RUN
+              value: {{ .Values.server_hotfix.autochainLhsToBatchRun | quote }}
+          command: ["/bin/sh", "-c", "/opt/hotfix/apply-hotfix.sh && exec /usr/local/bin/start-web-background"]
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    pkill -f -QUIT resque 2>/dev/null || true
+                    sleep {{ .Values.web_background.lifecycle.preStopSleepSeconds | quote }}
           livenessProbe:
             exec:
-              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
-            initialDelaySeconds: 5
-            periodSeconds: 30
-            timeoutSeconds: 30
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  grep -qs "/mnt/openstudio " /proc/mounts && \
+                  test -w /mnt/openstudio && \
+                  exit 0 || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            timeoutSeconds: 10
             failureThreshold: 3
       priorityClassName: high-priority
       volumes:
         - name: nfs
           persistentVolumeClaim:
             claimName: nfs-pvc
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+        {{- if .Values.server_hotfix.enabled }}
+        - name: server-hotfix-scripts
+          configMap:
+            name: server-hotfix-scripts
+            defaultMode: 0755
+        {{- end }}

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Values.web.name  }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.web.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Values.web.name  }}
@@ -19,6 +19,8 @@ spec:
         app: {{ .Values.web.name  }}
         release: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.web.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ .Values.web.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,10 +30,92 @@ spec:
                     operator: In
                     values:
                       - web-group
+        {{- if .Values.web.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          {{- if eq .Values.web.podAntiAffinity.type "required" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - {{ .Values.web.name }}
+                  - key: release
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: {{ .Values.web.podAntiAffinity.topologyKey }}
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.web.podAntiAffinity.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ .Values.web.name }}
+                    - key: release
+                      operator: In
+                      values:
+                        - {{ .Release.Name }}
+                topologyKey: {{ .Values.web.podAntiAffinity.topologyKey }}
+          {{- end }}
+        {{- end }}
+      {{- if .Values.web.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.web.topologySpread.maxSkew }}
+          topologyKey: {{ .Values.web.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ .Values.web.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.web.name }}
+              release: {{ .Release.Name }}
+      {{- end }}
       initContainers:
           - name: init-wait-for-db
             image: alpine
             command: ["/bin/sh", "-c", "for i in $(seq 1 300); do nc -zvw1 {{  .Values.db.name  }} {{ .Values.db.container.ports.db_port }} && exit 0 || sleep 3; done; exit 1"]
+          - name: init-verify-mnt-openstudio
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Verifying /mnt/openstudio mount..."
+                if [ ! -d "/mnt/openstudio" ]; then
+                  echo "ERROR: /mnt/openstudio directory does not exist"
+                  exit 1
+                fi
+                echo "Checking mount point..."
+                if ! grep -qs "/mnt/openstudio " /proc/mounts; then
+                  echo "ERROR: /mnt/openstudio is not mounted"
+                  exit 1
+                fi
+                echo "Verifying write permissions..."
+                TEST_FILE="/mnt/openstudio/.startup-check-$(date +%s)"
+                if ! touch "$TEST_FILE" 2>/dev/null; then
+                  echo "ERROR: /mnt/openstudio is not writable"
+                  exit 1
+                fi
+                rm -f "$TEST_FILE"
+                echo "SUCCESS: /mnt/openstudio is mounted and writable"
+            volumeMounts:
+              - name: nfs
+                mountPath: "/mnt/openstudio"
+          - name: init-nginx-config
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                echo "Injecting Nginx configuration with gzip enabled..."
+                cp /etc/nginx-config/nginx.conf /opt/nginx/conf/nginx.conf
+                echo "Nginx configuration injected successfully"
+            volumeMounts:
+              - name: nginx-config
+                mountPath: /etc/nginx-config
       containers:
         - name:  {{ .Values.web.container.name  }}
           image: {{ .Values.web.container.image  }}
@@ -40,12 +124,22 @@ spec:
             requests:
               cpu:  {{  .Values.web.container.resources.requests.cpu  }}
               memory:  {{  .Values.web.container.resources.requests.memory  }}
+            {{- with .Values.web.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.web.container.port.http  }}
             - containerPort: {{ .Values.web.container.port.https  }}
           volumeMounts:
             - name: nfs
               mountPath: "/mnt/openstudio"
+            {{- if .Values.server_hotfix.enabled }}
+            - name: server-hotfix-scripts
+              mountPath: /opt/hotfix
+              readOnly: true
+            {{- end }}
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
               value: {{ .Values.rserve.number_of_workers | quote }}
@@ -63,24 +157,104 @@ spec:
               value: {{ (ceil (mulf .Values.worker_hpa.maxReplicas 1.05)) | quote }}
             - name: MAX_POOL
               value: {{ (ceil (divf (mulf (trimSuffix "Gi" .Values.web.container.resources.requests.memory) 1024 0.75) .Values.web.passenger_memory_per_process)) | quote }}
-          command: ["bash", "-c", "/usr/local/bin/rails-entrypoint && /usr/local/bin/start-server"]
+            # Passenger performance tuning
+            - name: PASSENGER_MIN_INSTANCES
+              value: {{ .Values.web.passenger_min_instances | quote }}
+            - name: PASSENGER_MAX_POOL_SIZE
+              value: {{ .Values.web.passenger_max_pool_size | quote }}
+            - name: PASSENGER_REQUEST_QUEUE_OVERFLOW_TO_WAIT_LIST
+              value: {{ .Values.web.passenger_request_queue_overflow_to_wait_list | quote }}
+            - name: PASSENGER_MAX_REQUEST_QUEUE_SIZE
+              value: {{ .Values.web.passenger_max_request_queue_size | quote }}
+            - name: PASSENGER_RESTART_DIR
+              value: "/tmp/passenger-restart"
+            # Nginx compression and buffering
+            - name: NGINX_GZIP
+              value: {{ .Values.web.nginx_gzip | quote }}
+            - name: NGINX_GZIP_COMP_LEVEL
+              value: {{ .Values.web.nginx_gzip_comp_level | quote }}
+            - name: NGINX_GZIP_MIN_LENGTH
+              value: {{ .Values.web.nginx_gzip_min_length | quote }}
+            - name: NGINX_CLIENT_MAX_BODY_SIZE
+              value: {{ .Values.web.nginx_client_max_body_size | quote }}
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_connect_timeout | quote }}
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_send_timeout | quote }}
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_read_timeout | quote }}
+            - name: NGINX_PROXY_BUFFERING
+              value: {{ .Values.web.nginx_proxy_buffering | quote }}
+            - name: NGINX_PROXY_BUFFER_SIZE
+              value: {{ .Values.web.nginx_proxy_buffer_size | quote }}
+            - name: NGINX_PROXY_BUFFERS
+              value: {{ .Values.web.nginx_proxy_buffers | quote }}
+            - name: OS_SERVER_HOTFIX_ENFORCE_BATCH_RUN_START
+              value: {{ .Values.server_hotfix.enforceBatchRunStart | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_ENABLED
+              value: {{ .Values.server_hotfix.completedKeyTtlEnabled | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_SECONDS
+              value: {{ .Values.server_hotfix.completedKeyTtlSeconds | quote }}
+            - name: OS_SERVER_HOTFIX_AUTOCHAIN_LHS_TO_BATCH_RUN
+              value: {{ .Values.server_hotfix.autochainLhsToBatchRun | quote }}
+          command: ["bash", "-c", "/opt/hotfix/apply-hotfix.sh && /usr/local/bin/rails-entrypoint && /usr/local/bin/start-server & sleep 3 && sed -i 's/^[[:space:]]*gzip off;/    gzip on;/g' /opt/nginx/conf/nginx.conf && sed -i 's/passenger_max_pool_size 16;/passenger_max_pool_size 32;/g' /opt/nginx/conf/nginx.conf && pkill -HUP nginx; wait"]
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep {{ .Values.web.lifecycle.preStopSleepSeconds | quote }}
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    sleep 2
+                    pkill -HUP nginx || true
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.web.readinessProbe.path }}
               port: 80
-            initialDelaySeconds: 60
-            periodSeconds: 200
-            timeoutSeconds: 120
-            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           livenessProbe:
             exec:
-              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
-            initialDelaySeconds: 5
-            periodSeconds: 200
-            timeoutSeconds: 120
-            failureThreshold: 3
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  grep -qs "/mnt/openstudio " /proc/mounts && \
+                  test -w /mnt/openstudio && \
+                  exit 0 || exit 1
+            initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+          {{- if .Values.web.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.web.startupProbe.path }}
+              port: 80
+            initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          {{- end }}
       priorityClassName: high-priority
       volumes:
         - name: nfs
           persistentVolumeClaim:
             claimName: nfs-pvc
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+        {{- if .Values.server_hotfix.enabled }}
+        - name: server-hotfix-scripts
+          configMap:
+            name: server-hotfix-scripts
+            defaultMode: 0755
+        {{- end }}

--- a/openstudio-server/templates/worker/worker-deploy.yaml
+++ b/openstudio-server/templates/worker/worker-deploy.yaml
@@ -2,10 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.worker.name   }}
-  annotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: {{ .Values.worker.name }}
@@ -17,10 +14,13 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Values.worker.name }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.worker.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -37,17 +37,37 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ['/bin/sh', '-c', 'echo "Creating kill.worker file" >&2; touch /opt/openstudio/server/bin/kill.worker; echo "Sending QUIT signal to Resque" >&2; pkill -f -QUIT resque; echo "Waiting for Ruby or OpenStudio processes to end" >&2; while [ $(eval "pgrep -c ruby") -gt 1 ] || [ $(eval "pgrep -c openstudio") -gt 0 ]; do sleep 15; echo "Still waiting..." >&2; done; echo "Killing remaining processes" >&2; pkill -P 1;']
+                command: ['/bin/sh', '-c', 'TIMEOUT=280; ELAPSED=0; echo "$(date): Starting graceful shutdown (timeout ${TIMEOUT}s)" >&2; [ -d /opt/openstudio/server/bin ] && touch /opt/openstudio/server/bin/kill.worker 2>/dev/null || echo "$(date): kill.worker directory does not exist (OK)" >&2; echo "$(date): Created kill.worker file" >&2; pkill -f -QUIT resque 2>/dev/null || true; echo "$(date): Sent QUIT signal to Resque" >&2; while [ $ELAPSED -lt $TIMEOUT ]; do RUBY_COUNT=$(pgrep -c ruby 2>/dev/null || echo 0); OPENSTUDIO_COUNT=$(pgrep -c openstudio 2>/dev/null || echo 0); if [ "$RUBY_COUNT" -le 1 ] && [ "$OPENSTUDIO_COUNT" -eq 0 ]; then echo "$(date): All jobs completed successfully" >&2; break; fi; REMAINING=$((TIMEOUT - ELAPSED)); echo "$(date): Waiting ($REMAINING s remaining) - ruby=$RUBY_COUNT, openstudio=$OPENSTUDIO_COUNT" >&2; sleep 5; ELAPSED=$((ELAPSED + 5)); done; if [ $ELAPSED -ge $TIMEOUT ]; then echo "$(date): Timeout reached. Force killing remaining processes" >&2; pkill -P 1 2>/dev/null || true; else echo "$(date): Graceful shutdown completed" >&2; fi; exit 0']
+          startupProbe:
+            exec:
+              command: ['/bin/sh', '-c', 'pgrep -f "resque.*worker" > /dev/null && echo ready']
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command: ['/bin/sh', '-c', 'pgrep -f "resque.*worker" > /dev/null && echo ready']
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+            successThreshold: 2
+            timeoutSeconds: 5
           resources:
             requests:
               cpu:  {{  .Values.worker.container.resources.requests.cpu  }}
               memory:  {{  .Values.worker.container.resources.requests.memory  }}
+            {{- with .Values.worker.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           volumeMounts:
             - name: osdata-worker
               mountPath: "/mnt/openstudio"
           env:
             - name:  QUEUES
-              value: requeued,simulations
+              value: {{ .Values.worker.queues | quote }}
             - name:  COUNT
               value: "1"
             - name: SECRET_KEY_BASE

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -5,21 +5,40 @@
 
 # Set to google, aws, azure, or openstack
 provider:
-  name: ""
+  name: "aws"
 
 cluster:
   name: "openstudio-server-03"
 
+cluster_autoscaler:
+  expander: "least-waste"
+  scanInterval: "10s"
+  maxNodeProvisionTime: "3m"
+  scaleDownUtilizationThreshold: "0.2"
+  scaleDownUnneededTime: "10m"
+  maxGracefulTerminationSec: "120"
+  scaleDownDelayAfterFailure: "5m"
+
 nfs-server-provisioner:
+  service:
+    # Fixed ClusterIP used by RWX mount option `addr=` for Bottlerocket NFS mounts.
+    clusterIP: "10.100.148.127"
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 550Gi
+    size: 2Ti
   storageClass:
-    allowVolumeExpansion: false
+    allowVolumeExpansion: true
     mountOptions:
       - vers=4
-      - sync
+      - addr=10.100.148.127
+  resources:
+    requests:
+      cpu: 4
+      memory: "8Gi"
+    limits:
+      cpu: 8
+      memory: "16Gi"
 db:
   name:  "db"
   label: "db"
@@ -27,9 +46,17 @@ db:
   password: "openstudio"
   container:
     name: "mongo-db"
-    image: "mongo:6.0.7"
+  serviceAccount:
+    create: true
+    name: "db-sa"
+    annotations: {}
+
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/mongo:6.0.7"
     resources:
       requests:
+        cpu: 2
+        memory: "8Gi"
+      limits:
         cpu: 4
         memory: "12Gi"
     ports:
@@ -37,7 +64,7 @@ db:
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -60,7 +87,7 @@ nfs_pvc:
   name: "nfs-pvc"
   accessModes:
     - "ReadWriteMany"
-  storageClass: "ssd"
+  storageClass: "nfs"
   storage: "500Gi"
 
 
@@ -68,19 +95,27 @@ redis:
   name: "redis"
   label: "redis"
   password: "openstudio"
-  maxclients: 40000
+  maxclients: 100000
   container:
+  serviceAccount:
+    create: true
+    name: "redis-sa"
+    annotations: {}
+
     name: "redis"
-    image: "redis:6.0.9"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/redis:6.0.9"
     resources:
       requests:
-        cpu: 3
+        cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
     port: 6379
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -95,12 +130,20 @@ rserve:
   label: "rserve"
   number_of_workers: "1"
   container:
+  serviceAccount:
+    create: true
+    name: "rserve-sa"
+    annotations: {}
+
     name: "rserve"
-    image: "nrel/openstudio-rserve:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-rserve:3.10.0"
     resources:
       requests:
         cpu: 1
-        memory: "1Gi"
+        memory: "2Gi"
+      limits:
+        cpu: 2
+        memory: "4Gi"
 
 rserve_svc:
   name: "rserve"
@@ -110,34 +153,64 @@ rserve_svc:
 web_background:
   name: "web-background"
   label: "web-background"
-  replicas: 1
+  replicas:
+  serviceAccount:
+    create: true
+    name: "web-background-sa"
+    annotations: {}
+ 1
   container:
     name: "web-background"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
         cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
 
 web:
   name: "web"
   label: "web"
-  secret_key_value: "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
-  # passenger_max_request_queue_size: "1600"
-  # Use this formula (1024 * memory of web pod in Gi * 0.75) / memory per passenger process
-  # passenger_max_pool_size: "21"
-  # This value is typically between 150 and 400, find this by ssh into web pod and doing `passenger-status`
+  secret_key_value:
+  replicaCount: 1
+  terminationGracePeriodSeconds: 30
+  serviceAccount:
+    create: true
+    name: "web-sa"
+    annotations: {}
+ "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
+  # Passenger tuning parameters
   passenger_memory_per_process: 250
+  passenger_min_instances: 2
+  passenger_max_pool_size: 32
+  passenger_request_queue_overflow_to_wait_list: "true"
+  passenger_max_request_queue_size: 1600
+  # Nginx tuning parameters
+  nginx_gzip: "on"
+  nginx_gzip_comp_level: 6
+  nginx_gzip_min_length: 1024
+  nginx_client_max_body_size: "100m"
+  # Connection timeout for analyses.json download
+  nginx_proxy_connect_timeout: "90s"
+  nginx_proxy_send_timeout: "300s"
+  nginx_proxy_read_timeout: "300s"
+  nginx_proxy_buffering: "on"
+  nginx_proxy_buffer_size: "32k"
+  nginx_proxy_buffers: "8 32k"
+  # Health check tuning
+  health_check_timeout_analyses: 15
   container:
     name: "web"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
-        cpu: 6
-        memory: "50Gi"
-      limits:
         cpu: 8
-        memory: "60Gi"
+        memory: "32Gi"
+      limits:
+        cpu: 12
+        memory: "48Gi"
     port:
      http: 80
      https: 443
@@ -162,18 +235,82 @@ worker:
   name: "worker"
   label: "worker"
   container:
+  serviceAccount:
+    create: true
+    name: "worker-sa"
+    annotations: {}
+
     name: "worker"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0"
     resources:
       requests:
-        cpu: 500m
+        cpu: 600m
         memory: "1Gi"
+      limits:
+        cpu: 800m
+        memory: "2Gi"
     terminationGracePeriodSeconds: 180
 
 worker_hpa:
   name: "worker"
   minReplicas: 2
-  maxReplicas: 6600
-  targetCPUUtilizationPercentage: 10
-  stabilizationWindowSeconds: 300
-  scalePolicyValue: 950
+  maxReplicas: 15000
+  targetCPUUtilizationPercentage: 35
+  scaleUpStabilizationWindowSeconds: 0
+  scaleDownStabilizationWindowSeconds: 600
+  scaleUpPolicyValue: 500
+  scaleUpPolicyPeriodSeconds: 60
+  scaleDownPolicyValue: 25
+  scaleDownPolicyPeriodSeconds: 60
+
+s3_exporter:
+  enabled: false
+  schedule: "*/5 * * * *"
+  bucket: ""
+  prefix: ""
+  apiBaseUrl: "http://web"
+  nfsRoot: "/mnt/openstudio"
+  includeEnrichArtifacts: false
+  awsCliImage: "public.ecr.aws/aws-cli/aws-cli:2.17.49"
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  activeDeadlineSeconds: 1800
+  storageClass: ""
+  includePatterns:
+    - "manifest/*"
+    - "csv/*"
+  excludePatterns: []
+  serviceAccount:
+    create: true
+    name: "s3-sync-sa"
+    roleArn: ""
+    annotations: {}
+  resources:
+    collector:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+    uploader:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+
+pre_delete_hook:
+  serviceAccount:
+    create: true
+    name: "nfs-cleanup-sa"
+    annotations: {}
+
+security:
+  # Temporary compatibility switch for phased rollout.
+  # false: bind least-privilege Role to dedicated pre-delete hook SA (recommended)
+  # true: keep legacy default SA cluster-admin binding
+  legacyDefaultServiceAccountClusterAdmin:
+    enabled: false


### PR DESCRIPTION
## Summary

Replaces the legacy `cluster-admin` ClusterRoleBinding on the namespace `default` ServiceAccount with dedicated per-workload ServiceAccounts and a least-privilege Role scoped to the pre-delete hook.

## Changes

### New: `workload-serviceaccounts.yaml`
Creates dedicated ServiceAccounts for: `web`, `web-background`, `worker`, `rserve`, `db`, `redis`, `nfs-cleanup` (pre-delete hook).

### Updated: `nfs-disconnect-rbac.yaml`
- **Least-privilege path (default):** Creates a `Role` with only `delete` on specific Deployments, bound to `nfs-cleanup-sa`
- **Legacy path (opt-in):** Keeps the original `ClusterRoleBinding` cluster-admin binding for backwards compatibility
- Toggle: `security.legacyDefaultServiceAccountClusterAdmin.enabled` (default: `false`)

### Updated: All deployment specs
Each deployment now references its dedicated ServiceAccount via `spec.serviceAccountName`.

### Updated: `aws/cluster_setup.md`
Documents the two-phase SA hardening rollout (phase 1: set `legacyDefaultServiceAccountClusterAdmin.enabled=true`, phase 2: set `false`).

## Values Added
```yaml
db.serviceAccount.{create,name,annotations}
redis.serviceAccount.{create,name,annotations}
rserve.serviceAccount.{create,name,annotations}
web_background.serviceAccount.{create,name,annotations}
web.serviceAccount.{create,name,annotations}
worker.serviceAccount.{create,name,annotations}
pre_delete_hook.serviceAccount.{create,name,annotations}
security.legacyDefaultServiceAccountClusterAdmin.enabled
```

## Rollout Notes
Apply with `--set security.legacyDefaultServiceAccountClusterAdmin.enabled=true` first, verify no workload uses `default` SA, then flip to `false`.