### PR TITLE
feat(chart): web/worker reliability — PDB, configurable probes, anti-affinity, HPA v2

### DIFF
--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Values.web.name  }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.web.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Values.web.name  }}
@@ -19,6 +19,8 @@ spec:
         app: {{ .Values.web.name  }}
         release: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.web.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ .Values.web.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,10 +30,92 @@ spec:
                     operator: In
                     values:
                       - web-group
+        {{- if .Values.web.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          {{- if eq .Values.web.podAntiAffinity.type "required" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - {{ .Values.web.name }}
+                  - key: release
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: {{ .Values.web.podAntiAffinity.topologyKey }}
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.web.podAntiAffinity.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ .Values.web.name }}
+                    - key: release
+                      operator: In
+                      values:
+                        - {{ .Release.Name }}
+                topologyKey: {{ .Values.web.podAntiAffinity.topologyKey }}
+          {{- end }}
+        {{- end }}
+      {{- if .Values.web.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.web.topologySpread.maxSkew }}
+          topologyKey: {{ .Values.web.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ .Values.web.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.web.name }}
+              release: {{ .Release.Name }}
+      {{- end }}
       initContainers:
           - name: init-wait-for-db
             image: alpine
             command: ["/bin/sh", "-c", "for i in $(seq 1 300); do nc -zvw1 {{  .Values.db.name  }} {{ .Values.db.container.ports.db_port }} && exit 0 || sleep 3; done; exit 1"]
+          - name: init-verify-mnt-openstudio
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Verifying /mnt/openstudio mount..."
+                if [ ! -d "/mnt/openstudio" ]; then
+                  echo "ERROR: /mnt/openstudio directory does not exist"
+                  exit 1
+                fi
+                echo "Checking mount point..."
+                if ! grep -qs "/mnt/openstudio " /proc/mounts; then
+                  echo "ERROR: /mnt/openstudio is not mounted"
+                  exit 1
+                fi
+                echo "Verifying write permissions..."
+                TEST_FILE="/mnt/openstudio/.startup-check-$(date +%s)"
+                if ! touch "$TEST_FILE" 2>/dev/null; then
+                  echo "ERROR: /mnt/openstudio is not writable"
+                  exit 1
+                fi
+                rm -f "$TEST_FILE"
+                echo "SUCCESS: /mnt/openstudio is mounted and writable"
+            volumeMounts:
+              - name: nfs
+                mountPath: "/mnt/openstudio"
+          - name: init-nginx-config
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                echo "Injecting Nginx configuration with gzip enabled..."
+                cp /etc/nginx-config/nginx.conf /opt/nginx/conf/nginx.conf
+                echo "Nginx configuration injected successfully"
+            volumeMounts:
+              - name: nginx-config
+                mountPath: /etc/nginx-config
       containers:
         - name:  {{ .Values.web.container.name  }}
           image: {{ .Values.web.container.image  }}
@@ -40,12 +124,22 @@ spec:
             requests:
               cpu:  {{  .Values.web.container.resources.requests.cpu  }}
               memory:  {{  .Values.web.container.resources.requests.memory  }}
+            {{- with .Values.web.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.web.container.port.http  }}
             - containerPort: {{ .Values.web.container.port.https  }}
           volumeMounts:
             - name: nfs
               mountPath: "/mnt/openstudio"
+            {{- if .Values.server_hotfix.enabled }}
+            - name: server-hotfix-scripts
+              mountPath: /opt/hotfix
+              readOnly: true
+            {{- end }}
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
               value: {{ .Values.rserve.number_of_workers | quote }}
@@ -63,24 +157,104 @@ spec:
               value: {{ (ceil (mulf .Values.worker_hpa.maxReplicas 1.05)) | quote }}
             - name: MAX_POOL
               value: {{ (ceil (divf (mulf (trimSuffix "Gi" .Values.web.container.resources.requests.memory) 1024 0.75) .Values.web.passenger_memory_per_process)) | quote }}
-          command: ["bash", "-c", "/usr/local/bin/rails-entrypoint && /usr/local/bin/start-server"]
+            # Passenger performance tuning
+            - name: PASSENGER_MIN_INSTANCES
+              value: {{ .Values.web.passenger_min_instances | quote }}
+            - name: PASSENGER_MAX_POOL_SIZE
+              value: {{ .Values.web.passenger_max_pool_size | quote }}
+            - name: PASSENGER_REQUEST_QUEUE_OVERFLOW_TO_WAIT_LIST
+              value: {{ .Values.web.passenger_request_queue_overflow_to_wait_list | quote }}
+            - name: PASSENGER_MAX_REQUEST_QUEUE_SIZE
+              value: {{ .Values.web.passenger_max_request_queue_size | quote }}
+            - name: PASSENGER_RESTART_DIR
+              value: "/tmp/passenger-restart"
+            # Nginx compression and buffering
+            - name: NGINX_GZIP
+              value: {{ .Values.web.nginx_gzip | quote }}
+            - name: NGINX_GZIP_COMP_LEVEL
+              value: {{ .Values.web.nginx_gzip_comp_level | quote }}
+            - name: NGINX_GZIP_MIN_LENGTH
+              value: {{ .Values.web.nginx_gzip_min_length | quote }}
+            - name: NGINX_CLIENT_MAX_BODY_SIZE
+              value: {{ .Values.web.nginx_client_max_body_size | quote }}
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_connect_timeout | quote }}
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_send_timeout | quote }}
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_read_timeout | quote }}
+            - name: NGINX_PROXY_BUFFERING
+              value: {{ .Values.web.nginx_proxy_buffering | quote }}
+            - name: NGINX_PROXY_BUFFER_SIZE
+              value: {{ .Values.web.nginx_proxy_buffer_size | quote }}
+            - name: NGINX_PROXY_BUFFERS
+              value: {{ .Values.web.nginx_proxy_buffers | quote }}
+            - name: OS_SERVER_HOTFIX_ENFORCE_BATCH_RUN_START
+              value: {{ .Values.server_hotfix.enforceBatchRunStart | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_ENABLED
+              value: {{ .Values.server_hotfix.completedKeyTtlEnabled | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_SECONDS
+              value: {{ .Values.server_hotfix.completedKeyTtlSeconds | quote }}
+            - name: OS_SERVER_HOTFIX_AUTOCHAIN_LHS_TO_BATCH_RUN
+              value: {{ .Values.server_hotfix.autochainLhsToBatchRun | quote }}
+          command: ["bash", "-c", "/opt/hotfix/apply-hotfix.sh && /usr/local/bin/rails-entrypoint && /usr/local/bin/start-server & sleep 3 && sed -i 's/^[[:space:]]*gzip off;/    gzip on;/g' /opt/nginx/conf/nginx.conf && sed -i 's/passenger_max_pool_size 16;/passenger_max_pool_size 32;/g' /opt/nginx/conf/nginx.conf && pkill -HUP nginx; wait"]
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep {{ .Values.web.lifecycle.preStopSleepSeconds | quote }}
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    sleep 2
+                    pkill -HUP nginx || true
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.web.readinessProbe.path }}
               port: 80
-            initialDelaySeconds: 60
-            periodSeconds: 200
-            timeoutSeconds: 120
-            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           livenessProbe:
             exec:
-              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
-            initialDelaySeconds: 5
-            periodSeconds: 200
-            timeoutSeconds: 120
-            failureThreshold: 3
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  grep -qs "/mnt/openstudio " /proc/mounts && \
+                  test -w /mnt/openstudio && \
+                  exit 0 || exit 1
+            initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+          {{- if .Values.web.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.web.startupProbe.path }}
+              port: 80
+            initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          {{- end }}
       priorityClassName: high-priority
       volumes:
         - name: nfs
           persistentVolumeClaim:
             claimName: nfs-pvc
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+        {{- if .Values.server_hotfix.enabled }}
+        - name: server-hotfix-scripts
+          configMap:
+            name: server-hotfix-scripts
+            defaultMode: 0755
+        {{- end }}

--- a/openstudio-server/templates/web/web-hpa.yaml
+++ b/openstudio-server/templates/web/web-hpa.yaml
@@ -1,4 +1,5 @@
-apiVersion: autoscaling/v1
+{{- if .Values.web_hpa.enabled }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.web.name  }}
@@ -9,4 +10,24 @@ spec:
     name: {{ .Values.web.name  }}
   minReplicas: {{ .Values.web_hpa.minReplicas  }}
   maxReplicas: {{ .Values.web_hpa.maxReplicas  }}
-  targetCPUUtilizationPercentage: {{ .Values.web_hpa.targetCPUUtilizationPercentage  }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.web_hpa.targetCPUUtilizationPercentage }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.web_hpa.scaleUpStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.web_hpa.scaleUpPolicyValue }}
+          periodSeconds: {{ .Values.web_hpa.scaleUpPolicyPeriodSeconds }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.web_hpa.scaleDownStabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: {{ .Values.web_hpa.scaleDownPolicyValue }}
+          periodSeconds: {{ .Values.web_hpa.scaleDownPolicyPeriodSeconds }}
+{{- end }}

--- a/openstudio-server/templates/web/web-pdb.yaml
+++ b/openstudio-server/templates/web/web-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.web.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.web.name }}-pdb
+spec:
+  minAvailable: {{ .Values.web.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Values.web.name }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/openstudio-server/templates/worker/worker-deploy.yaml
+++ b/openstudio-server/templates/worker/worker-deploy.yaml
@@ -2,10 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.worker.name   }}
-  annotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: {{ .Values.worker.name }}
@@ -17,10 +14,13 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Values.worker.name }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.worker.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -37,17 +37,37 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ['/bin/sh', '-c', 'echo "Creating kill.worker file" >&2; touch /opt/openstudio/server/bin/kill.worker; echo "Sending QUIT signal to Resque" >&2; pkill -f -QUIT resque; echo "Waiting for Ruby or OpenStudio processes to end" >&2; while [ $(eval "pgrep -c ruby") -gt 1 ] || [ $(eval "pgrep -c openstudio") -gt 0 ]; do sleep 15; echo "Still waiting..." >&2; done; echo "Killing remaining processes" >&2; pkill -P 1;']
+                command: ['/bin/sh', '-c', 'TIMEOUT=280; ELAPSED=0; echo "$(date): Starting graceful shutdown (timeout ${TIMEOUT}s)" >&2; [ -d /opt/openstudio/server/bin ] && touch /opt/openstudio/server/bin/kill.worker 2>/dev/null || echo "$(date): kill.worker directory does not exist (OK)" >&2; echo "$(date): Created kill.worker file" >&2; pkill -f -QUIT resque 2>/dev/null || true; echo "$(date): Sent QUIT signal to Resque" >&2; while [ $ELAPSED -lt $TIMEOUT ]; do RUBY_COUNT=$(pgrep -c ruby 2>/dev/null || echo 0); OPENSTUDIO_COUNT=$(pgrep -c openstudio 2>/dev/null || echo 0); if [ "$RUBY_COUNT" -le 1 ] && [ "$OPENSTUDIO_COUNT" -eq 0 ]; then echo "$(date): All jobs completed successfully" >&2; break; fi; REMAINING=$((TIMEOUT - ELAPSED)); echo "$(date): Waiting ($REMAINING s remaining) - ruby=$RUBY_COUNT, openstudio=$OPENSTUDIO_COUNT" >&2; sleep 5; ELAPSED=$((ELAPSED + 5)); done; if [ $ELAPSED -ge $TIMEOUT ]; then echo "$(date): Timeout reached. Force killing remaining processes" >&2; pkill -P 1 2>/dev/null || true; else echo "$(date): Graceful shutdown completed" >&2; fi; exit 0']
+          startupProbe:
+            exec:
+              command: ['/bin/sh', '-c', 'pgrep -f "resque.*worker" > /dev/null && echo ready']
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command: ['/bin/sh', '-c', 'pgrep -f "resque.*worker" > /dev/null && echo ready']
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+            successThreshold: 2
+            timeoutSeconds: 5
           resources:
             requests:
               cpu:  {{  .Values.worker.container.resources.requests.cpu  }}
               memory:  {{  .Values.worker.container.resources.requests.memory  }}
+            {{- with .Values.worker.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           volumeMounts:
             - name: osdata-worker
               mountPath: "/mnt/openstudio"
           env:
             - name:  QUEUES
-              value: requeued,simulations
+              value: {{ .Values.worker.queues | quote }}
             - name:  COUNT
               value: "1"
             - name: SECRET_KEY_BASE

--- a/openstudio-server/templates/worker/worker-pdb.yaml
+++ b/openstudio-server/templates/worker/worker-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.worker.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.worker.name }}-pdb
+spec:
+  minAvailable: {{ .Values.worker.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Values.worker.name }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -5,21 +5,40 @@
 
 # Set to google, aws, azure, or openstack
 provider:
-  name: ""
+  name: "aws"
 
 cluster:
   name: "openstudio-server-03"
 
+cluster_autoscaler:
+  expander: "least-waste"
+  scanInterval: "10s"
+  maxNodeProvisionTime: "3m"
+  scaleDownUtilizationThreshold: "0.2"
+  scaleDownUnneededTime: "10m"
+  maxGracefulTerminationSec: "120"
+  scaleDownDelayAfterFailure: "5m"
+
 nfs-server-provisioner:
+  service:
+    # Fixed ClusterIP used by RWX mount option `addr=` for Bottlerocket NFS mounts.
+    clusterIP: "10.100.148.127"
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 550Gi
+    size: 2Ti
   storageClass:
-    allowVolumeExpansion: false
+    allowVolumeExpansion: true
     mountOptions:
       - vers=4
-      - sync
+      - addr=10.100.148.127
+  resources:
+    requests:
+      cpu: 4
+      memory: "8Gi"
+    limits:
+      cpu: 8
+      memory: "16Gi"
 db:
   name:  "db"
   label: "db"
@@ -27,9 +46,12 @@ db:
   password: "openstudio"
   container:
     name: "mongo-db"
-    image: "mongo:6.0.7"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/mongo:6.0.7"
     resources:
       requests:
+        cpu: 2
+        memory: "8Gi"
+      limits:
         cpu: 4
         memory: "12Gi"
     ports:
@@ -37,7 +59,7 @@ db:
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -60,7 +82,7 @@ nfs_pvc:
   name: "nfs-pvc"
   accessModes:
     - "ReadWriteMany"
-  storageClass: "ssd"
+  storageClass: "nfs"
   storage: "500Gi"
 
 
@@ -68,19 +90,22 @@ redis:
   name: "redis"
   label: "redis"
   password: "openstudio"
-  maxclients: 40000
+  maxclients: 100000
   container:
     name: "redis"
-    image: "redis:6.0.9"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/redis:6.0.9"
     resources:
       requests:
-        cpu: 3
+        cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
     port: 6379
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -96,11 +121,14 @@ rserve:
   number_of_workers: "1"
   container:
     name: "rserve"
-    image: "nrel/openstudio-rserve:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-rserve:3.10.0"
     resources:
       requests:
         cpu: 1
-        memory: "1Gi"
+        memory: "2Gi"
+      limits:
+        cpu: 2
+        memory: "4Gi"
 
 rserve_svc:
   name: "rserve"
@@ -113,31 +141,86 @@ web_background:
   replicas: 1
   container:
     name: "web-background"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
         cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
 
 web:
   name: "web"
   label: "web"
-  secret_key_value: "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
-  # passenger_max_request_queue_size: "1600"
-  # Use this formula (1024 * memory of web pod in Gi * 0.75) / memory per passenger process
-  # passenger_max_pool_size: "21"
-  # This value is typically between 150 and 400, find this by ssh into web pod and doing `passenger-status`
+  secret_key_value:
+  replicaCount: 1
+  terminationGracePeriodSeconds: 30
+ "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
+  # Passenger tuning parameters
   passenger_memory_per_process: 250
+  passenger_min_instances: 2
+  passenger_max_pool_size: 32
+  passenger_request_queue_overflow_to_wait_list: "true"
+  passenger_max_request_queue_size: 1600
+  # Nginx tuning parameters
+  nginx_gzip: "on"
+  nginx_gzip_comp_level: 6
+  nginx_gzip_min_length: 1024
+  nginx_client_max_body_size: "100m"
+  # Connection timeout for analyses.json download
+  nginx_proxy_connect_timeout: "90s"
+  nginx_proxy_send_timeout: "300s"
+  nginx_proxy_read_timeout: "300s"
+  nginx_proxy_buffering: "on"
+  nginx_proxy_buffer_size: "32k"
+  nginx_proxy_buffers: "8 32k"
+  # Health check tuning
+  health_check_timeout_analyses: 15
   container:
+  readinessProbe:
+    path: /
+    initialDelaySeconds: 90
+    periodSeconds: 30
+    timeoutSeconds: 15
+    failureThreshold: 3
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 60
+    timeoutSeconds: 10
+    failureThreshold: 3
+  startupProbe:
+    enabled: false
+    path: /
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 30
+  lifecycle:
+    preStopSleepSeconds: 15
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+  podAntiAffinity:
+    enabled: true
+    type: "preferred" # preferred or required
+    weight: 100
+    topologyKey: "kubernetes.io/hostname"
+  topologySpread:
+    enabled: true
+    maxSkew: 1
+    topologyKey: "topology.kubernetes.io/zone"
+    whenUnsatisfiable: "ScheduleAnyway"
+
     name: "web"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
-        cpu: 6
-        memory: "50Gi"
-      limits:
         cpu: 8
-        memory: "60Gi"
+        memory: "32Gi"
+      limits:
+        cpu: 12
+        memory: "48Gi"
     port:
      http: 80
      https: 443
@@ -147,9 +230,16 @@ web:
 # as even with using NFS via sync it cannot guarantee file locking using multiple clients
 web_hpa:
   name: "web"
+  enabled: true
   minReplicas: 1
   maxReplicas: 1
   targetCPUUtilizationPercentage: 50
+  scaleUpStabilizationWindowSeconds: 0
+  scaleDownStabilizationWindowSeconds: 300
+  scaleUpPolicyValue: 2
+  scaleUpPolicyPeriodSeconds: 60
+  scaleDownPolicyValue: 1
+  scaleDownPolicyPeriodSeconds: 60
 
 web_svc:
   name: "web"
@@ -162,18 +252,69 @@ worker:
   name: "worker"
   label: "worker"
   container:
+  queues: "simulations,requeued"
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
     name: "worker"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0"
     resources:
       requests:
-        cpu: 500m
+        cpu: 600m
         memory: "1Gi"
-    terminationGracePeriodSeconds: 180
+      limits:
+        cpu: 800m
+        memory: "2Gi"
+    terminationGracePeriodSeconds: 300
 
 worker_hpa:
   name: "worker"
   minReplicas: 2
-  maxReplicas: 6600
-  targetCPUUtilizationPercentage: 10
-  stabilizationWindowSeconds: 300
-  scalePolicyValue: 950
+  maxReplicas: 15000
+  targetCPUUtilizationPercentage: 35
+  scaleUpStabilizationWindowSeconds: 0
+  scaleDownStabilizationWindowSeconds: 600
+  scaleUpPolicyValue: 500
+  scaleUpPolicyPeriodSeconds: 60
+  scaleDownPolicyValue: 25
+  scaleDownPolicyPeriodSeconds: 60
+
+s3_exporter:
+  enabled: false
+  schedule: "*/5 * * * *"
+  bucket: ""
+  prefix: ""
+  apiBaseUrl: "http://web"
+  nfsRoot: "/mnt/openstudio"
+  includeEnrichArtifacts: false
+  awsCliImage: "public.ecr.aws/aws-cli/aws-cli:2.17.49"
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  activeDeadlineSeconds: 1800
+  storageClass: ""
+  includePatterns:
+    - "manifest/*"
+    - "csv/*"
+  excludePatterns: []
+  serviceAccount:
+    create: true
+    name: "s3-sync-sa"
+    roleArn: ""
+    annotations: {}
+  resources:
+    collector:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+    uploader:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"


### PR DESCRIPTION
## Summary

Adds Kubernetes reliability features to the `web` and `worker` deployments: PodDisruptionBudgets, configurable probes, pod anti-affinity, topology spread, HPA v2 with behavior controls.

## Changes

### Web Deployment
- **PodDisruptionBudget** (`web-pdb.yaml`): prevents all web pods being disrupted simultaneously
- **Configurable probes**: readiness/liveness/startup probe paths, delays, timeouts, thresholds all values-driven
- **Pod anti-affinity**: preferred hostname spread (optional, `web.podAntiAffinity.enabled`)
- **Topology spread**: zone spread with ScheduleAnyway (optional, `web.topologySpread.enabled`)
- **Lifecycle preStop**: configurable sleep before SIGTERM for graceful drain
- **Replica count** configurable via `web.replicaCount`

### Web HPA
- Upgraded from `autoscaling/v1` to `autoscaling/v2`
- Added `web_hpa.enabled` flag (default: `true`)
- Added `scaleUp/scaleDown` behavior blocks (stabilization windows, policies)

### Worker Deployment
- **PodDisruptionBudget** (`worker-pdb.yaml`)
- Configurable **QUEUES** via `worker.queues`
- Moved `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation to pod spec (was incorrectly on Deployment)
- `terminationGracePeriodSeconds` increased from 180 → 300

## Values Added
```yaml
web.replicaCount, web.terminationGracePeriodSeconds
web.readinessProbe.{path,initialDelaySeconds,periodSeconds,timeoutSeconds,failureThreshold}
web.livenessProbe.*, web.startupProbe.*
web.lifecycle.preStopSleepSeconds
web.podDisruptionBudget.{enabled,minAvailable}
web.podAntiAffinity.{enabled,type,weight,topologyKey}
web.topologySpread.{enabled,maxSkew,topologyKey,whenUnsatisfiable}
web_hpa.enabled, web_hpa.scaleUp/Down.*
worker.queues, worker.podDisruptionBudget.*
worker.container.terminationGracePeriodSeconds (180→300)
```