### PR TITLE
feat(chart): runtime server hotfix mechanism via configmap

### DIFF
--- a/openstudio-server/templates/hotfix/server-hotfix-configmap.yaml
+++ b/openstudio-server/templates/hotfix/server-hotfix-configmap.yaml
@@ -1,0 +1,149 @@
+{{- if .Values.server_hotfix.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: server-hotfix-scripts
+data:
+  apply-hotfix.sh: |
+    #!/usr/bin/env sh
+    set -eu
+
+    if [ "${OS_SERVER_HOTFIX_ENFORCE_BATCH_RUN_START:-true}" = "true" ]; then
+      ruby /opt/hotfix/patch-start-guards.rb
+      ruby /opt/hotfix/patch-start-analysis-type-option.rb
+    fi
+
+    if [ "${OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_ENABLED:-true}" = "true" ]; then
+      ruby /opt/hotfix/patch-completed-ttl.rb
+    fi
+
+    if [ "${OS_SERVER_HOTFIX_AUTOCHAIN_LHS_TO_BATCH_RUN:-true}" = "true" ]; then
+      ruby /opt/hotfix/patch-lhs-autochain.rb
+    fi
+
+    echo "OpenStudio server hotfix applied"
+
+  patch-start-guards.rb: |
+    controller = "/opt/openstudio/server/app/controllers/analyses_controller.rb"
+    marker = "OS_SERVER_HOTFIX_START_GUARDS_V1"
+    content = File.read(controller)
+
+    unless content.include?(marker)
+      guard_block = <<~'GUARD_BLOCK'
+          # OS_SERVER_HOTFIX_START_GUARDS_V1
+          requested_analysis_type = params[:analysis_type].to_s
+          if params[:analysis_action] == 'start'
+            if requested_analysis_type.present? && !['batch_run', 'lhs'].include?(requested_analysis_type)
+              render json: {
+                code: 422,
+                error: "analysis_type '#{requested_analysis_type}' is not allowed for start; supported values are batch_run, lhs, or omitted"
+              }, status: :unprocessable_entity and return
+            end
+
+            # Ensure downstream jobs can rely on analysis_type in run_options.
+            options[:analysis_type] = @analysis_type
+
+            active_statuses = ['na', 'init', 'queued', 'started', 'post-processing']
+            if @analysis.jobs.where(:status.in => active_statuses).exists?
+              render json: {
+                code: 409,
+                error: 'analysis already has an active run; refusing duplicate start'
+              }, status: :conflict and return
+            end
+
+            # Prevent duplicate LHS generation retries from creating multiple NA batches.
+            if requested_analysis_type == 'lhs' && @analysis.data_points.where(status: 'na').exists?
+              render json: {
+                code: 409,
+                error: 'lhs samples already generated for this analysis; start batch_run (or omit analysis_type) to queue simulations'
+              }, status: :conflict and return
+            end
+          end
+
+      GUARD_BLOCK
+
+      anchor = /(options\s*=\s*params\.permit!\.to_h\s*\n\s*options\[:run_data_point_filename\]\s*=\s*params\[:run_data_point_filename\]\s*if\s*params\[:run_data_point_filename\]\s*\n)/m
+      if content.match?(anchor)
+        content = content.sub(anchor) { |m| "#{m}\n#{guard_block}" }
+        File.write(controller, content)
+      else
+        warn("hotfix warning: start guard anchor not found in analyses_controller.rb; skipping")
+      end
+    end
+
+  patch-completed-ttl.rb: |
+    run_analysis = "/opt/openstudio/server/app/jobs/resque_jobs/run_analysis.rb"
+    marker = "OS_SERVER_HOTFIX_COMPLETED_TTL_V1"
+    content = File.read(run_analysis)
+
+    unless content.include?(marker)
+      replacement = <<~'COMPLETION_PATCH'.chomp
+            # OS_SERVER_HOTFIX_COMPLETED_TTL_V1
+            if analysis_type == 'batch_run'
+              ttl_seconds = Integer(ENV.fetch('OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_SECONDS', '900'))
+              Resque.redis.setex("analysis:#{analysis_id}:completed", ttl_seconds, true)
+            end
+      COMPLETION_PATCH
+
+      anchor = /^\s*Resque\.redis\.set\("analysis:\#\{analysis_id\}:completed",\s*true\)\s*$/
+      if content.match?(anchor)
+        content = content.sub(anchor, replacement)
+        File.write(run_analysis, content)
+      else
+        warn("hotfix warning: completion key assignment not found in run_analysis.rb; skipping")
+      end
+    end
+
+  patch-start-analysis-type-option.rb: |
+    controller = "/opt/openstudio/server/app/controllers/analyses_controller.rb"
+    content = File.read(controller)
+
+    unless content.include?("options[:analysis_type] = @analysis_type")
+      anchor = 'logger.debug("After parsing JSON arguments and default values, analysis will run with the following options #{options}")'
+      insertion = <<~'INSERTION'
+
+        # OS_SERVER_HOTFIX_START_ANALYSIS_TYPE_OPTION_V1
+        if params[:analysis_action] == 'start'
+          # Required by AnalysisLibrary::Core.initialize_analysis_job which uses options[:analysis_type] as a hash key.
+          options[:analysis_type] = @analysis_type
+        end
+
+      INSERTION
+
+      if content.include?(anchor)
+        content = content.sub(anchor, "#{insertion}#{anchor}")
+        File.write(controller, content)
+      else
+        warn("hotfix warning: analysis_type option insertion anchor not found in analyses_controller.rb; skipping")
+      end
+    end
+
+  patch-lhs-autochain.rb: |
+    run_analysis = "/opt/openstudio/server/app/jobs/resque_jobs/run_analysis.rb"
+    marker = "OS_SERVER_HOTFIX_LHS_AUTOCHAIN_V1"
+    content = File.read(run_analysis)
+
+    unless content.include?(marker)
+      replacement = <<~'AUTOCHAIN_PATCH'
+          # OS_SERVER_HOTFIX_LHS_AUTOCHAIN_V1
+          def self.after_perform_finalize_analysis(analysis_type, analysis_id, job_id, options = {})
+            if analysis_type == 'batch_run'
+              Resque.enqueue(FinalizeAnalysis, analysis_id)
+            else
+              follow_on_options = (options || {}).dup
+              follow_on_options['skip_init'] = true
+              follow_on_options['analysis_type'] = 'batch_run'
+              Resque.enqueue(self, 'batch_run', analysis_id, job_id, follow_on_options)
+            end
+          end
+      AUTOCHAIN_PATCH
+
+      anchor = /def self\.after_perform_finalize_analysis\([^\n]*\)\s*\n(?:\s*#.*\n)*\s*Resque\.enqueue\(FinalizeAnalysis,\s*analysis_id\)\s*\n\s*end/m
+      if content.match?(anchor)
+        content = content.sub(anchor, replacement)
+        File.write(run_analysis, content)
+      else
+        warn("hotfix warning: finalize hook not found in run_analysis.rb; skipping")
+      end
+    end
+{{- end }}

--- a/openstudio-server/templates/web-background/web-background-deploy.yaml
+++ b/openstudio-server/templates/web-background/web-background-deploy.yaml
@@ -3,7 +3,13 @@ kind: Deployment
 metadata:
   name: {{  .Values.web_background.name  }}
 spec:
-  replicas: {{  .Values.web_background.replicas  }}
+{{- if .Values.web_background_hpa.enabled }}
+  replicas: {{ .Values.web_background_hpa.minReplicas }}
+{{- else if .Values.web_background_keda.enabled }}
+  replicas: {{ .Values.web_background_keda.minReplicas }}
+{{- else }}
+  replicas: {{ .Values.web_background.replicas }}
+{{- end }}
   selector:
     matchLabels:
       app: {{  .Values.web_background.name  }}
@@ -19,6 +25,8 @@ spec:
         app: {{  .Values.web_background.name  }}
         release: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.web_background.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ .Values.web_background.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,6 +36,47 @@ spec:
                     operator: In
                     values:
                       - web-group
+      initContainers:
+          - name: init-verify-mnt-openstudio
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Verifying /mnt/openstudio mount..."
+                if [ ! -d "/mnt/openstudio" ]; then
+                  echo "ERROR: /mnt/openstudio directory does not exist"
+                  exit 1
+                fi
+                echo "Checking mount point..."
+                if ! grep -qs "/mnt/openstudio " /proc/mounts; then
+                  echo "ERROR: /mnt/openstudio is not mounted"
+                  exit 1
+                fi
+                echo "Verifying write permissions..."
+                TEST_FILE="/mnt/openstudio/.startup-check-$(date +%s)"
+                if ! touch "$TEST_FILE" 2>/dev/null; then
+                  echo "ERROR: /mnt/openstudio is not writable"
+                  exit 1
+                fi
+                rm -f "$TEST_FILE"
+                echo "SUCCESS: /mnt/openstudio is mounted and writable"
+            volumeMounts:
+              - name: nfs
+                mountPath: "/mnt/openstudio"
+          - name: init-nginx-config
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                echo "Injecting Nginx configuration with gzip enabled..."
+                cp /etc/nginx-config/nginx.conf /opt/nginx/conf/nginx.conf
+                echo "Nginx configuration injected successfully"
+            volumeMounts:
+              - name: nginx-config
+                mountPath: /etc/nginx-config
       containers:
         - name:  {{  .Values.web_background.container.name  }}
           image:  {{  .Values.web_background.container.image  }}
@@ -36,32 +85,78 @@ spec:
             requests:
               cpu:  {{  .Values.web_background.container.resources.requests.cpu  }}
               memory:  {{  .Values.web_background.container.resources.requests.memory  }}
+            {{- with .Values.web_background.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           volumeMounts:
             - name: nfs
               mountPath: "/mnt/openstudio"
+            {{- if .Values.server_hotfix.enabled }}
+            - name: server-hotfix-scripts
+              mountPath: /opt/hotfix
+              readOnly: true
+            {{- end }}
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
               value: {{ .Values.rserve.number_of_workers | quote }}
             - name: QUEUES
-              value: background,analyses
+              value: {{ .Values.web_background.queues | quote }}
             - name: SECRET_KEY_BASE
               value: {{ .Values.web.secret_key_value }}
             - name: REDIS_URL
               value: {{ .Values.redis_svc.url  }}
+{{- if .Values.web_background_keda.enabled }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.redis.password }}
+{{- end }}
             - name: MONGO_USER
               value: {{ .Values.db.username }}
             - name: MONGO_PASSWORD
               value: {{ .Values.db.password }}
-          command: ["/usr/local/bin/start-web-background"]
+            - name: OS_SERVER_HOTFIX_ENFORCE_BATCH_RUN_START
+              value: {{ .Values.server_hotfix.enforceBatchRunStart | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_ENABLED
+              value: {{ .Values.server_hotfix.completedKeyTtlEnabled | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_SECONDS
+              value: {{ .Values.server_hotfix.completedKeyTtlSeconds | quote }}
+            - name: OS_SERVER_HOTFIX_AUTOCHAIN_LHS_TO_BATCH_RUN
+              value: {{ .Values.server_hotfix.autochainLhsToBatchRun | quote }}
+          command: ["/bin/sh", "-c", "/opt/hotfix/apply-hotfix.sh && exec /usr/local/bin/start-web-background"]
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    pkill -f -QUIT resque 2>/dev/null || true
+                    sleep {{ .Values.web_background.lifecycle.preStopSleepSeconds | quote }}
           livenessProbe:
             exec:
-              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
-            initialDelaySeconds: 5
-            periodSeconds: 30
-            timeoutSeconds: 30
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  grep -qs "/mnt/openstudio " /proc/mounts && \
+                  test -w /mnt/openstudio && \
+                  exit 0 || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            timeoutSeconds: 10
             failureThreshold: 3
       priorityClassName: high-priority
       volumes:
         - name: nfs
           persistentVolumeClaim:
             claimName: nfs-pvc
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+        {{- if .Values.server_hotfix.enabled }}
+        - name: server-hotfix-scripts
+          configMap:
+            name: server-hotfix-scripts
+            defaultMode: 0755
+        {{- end }}

--- a/openstudio-server/templates/web/web-deploy.yaml
+++ b/openstudio-server/templates/web/web-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Values.web.name  }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.web.replicaCount }}
   selector:
     matchLabels:
       app: {{ .Values.web.name  }}
@@ -19,6 +19,8 @@ spec:
         app: {{ .Values.web.name  }}
         release: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.web.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ .Values.web.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,10 +30,92 @@ spec:
                     operator: In
                     values:
                       - web-group
+        {{- if .Values.web.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          {{- if eq .Values.web.podAntiAffinity.type "required" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - {{ .Values.web.name }}
+                  - key: release
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: {{ .Values.web.podAntiAffinity.topologyKey }}
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.web.podAntiAffinity.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ .Values.web.name }}
+                    - key: release
+                      operator: In
+                      values:
+                        - {{ .Release.Name }}
+                topologyKey: {{ .Values.web.podAntiAffinity.topologyKey }}
+          {{- end }}
+        {{- end }}
+      {{- if .Values.web.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.web.topologySpread.maxSkew }}
+          topologyKey: {{ .Values.web.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ .Values.web.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.web.name }}
+              release: {{ .Release.Name }}
+      {{- end }}
       initContainers:
           - name: init-wait-for-db
             image: alpine
             command: ["/bin/sh", "-c", "for i in $(seq 1 300); do nc -zvw1 {{  .Values.db.name  }} {{ .Values.db.container.ports.db_port }} && exit 0 || sleep 3; done; exit 1"]
+          - name: init-verify-mnt-openstudio
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Verifying /mnt/openstudio mount..."
+                if [ ! -d "/mnt/openstudio" ]; then
+                  echo "ERROR: /mnt/openstudio directory does not exist"
+                  exit 1
+                fi
+                echo "Checking mount point..."
+                if ! grep -qs "/mnt/openstudio " /proc/mounts; then
+                  echo "ERROR: /mnt/openstudio is not mounted"
+                  exit 1
+                fi
+                echo "Verifying write permissions..."
+                TEST_FILE="/mnt/openstudio/.startup-check-$(date +%s)"
+                if ! touch "$TEST_FILE" 2>/dev/null; then
+                  echo "ERROR: /mnt/openstudio is not writable"
+                  exit 1
+                fi
+                rm -f "$TEST_FILE"
+                echo "SUCCESS: /mnt/openstudio is mounted and writable"
+            volumeMounts:
+              - name: nfs
+                mountPath: "/mnt/openstudio"
+          - name: init-nginx-config
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                echo "Injecting Nginx configuration with gzip enabled..."
+                cp /etc/nginx-config/nginx.conf /opt/nginx/conf/nginx.conf
+                echo "Nginx configuration injected successfully"
+            volumeMounts:
+              - name: nginx-config
+                mountPath: /etc/nginx-config
       containers:
         - name:  {{ .Values.web.container.name  }}
           image: {{ .Values.web.container.image  }}
@@ -40,12 +124,22 @@ spec:
             requests:
               cpu:  {{  .Values.web.container.resources.requests.cpu  }}
               memory:  {{  .Values.web.container.resources.requests.memory  }}
+            {{- with .Values.web.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.web.container.port.http  }}
             - containerPort: {{ .Values.web.container.port.https  }}
           volumeMounts:
             - name: nfs
               mountPath: "/mnt/openstudio"
+            {{- if .Values.server_hotfix.enabled }}
+            - name: server-hotfix-scripts
+              mountPath: /opt/hotfix
+              readOnly: true
+            {{- end }}
           env:
             - name: OS_SERVER_NUMBER_OF_WORKERS
               value: {{ .Values.rserve.number_of_workers | quote }}
@@ -63,24 +157,104 @@ spec:
               value: {{ (ceil (mulf .Values.worker_hpa.maxReplicas 1.05)) | quote }}
             - name: MAX_POOL
               value: {{ (ceil (divf (mulf (trimSuffix "Gi" .Values.web.container.resources.requests.memory) 1024 0.75) .Values.web.passenger_memory_per_process)) | quote }}
-          command: ["bash", "-c", "/usr/local/bin/rails-entrypoint && /usr/local/bin/start-server"]
+            # Passenger performance tuning
+            - name: PASSENGER_MIN_INSTANCES
+              value: {{ .Values.web.passenger_min_instances | quote }}
+            - name: PASSENGER_MAX_POOL_SIZE
+              value: {{ .Values.web.passenger_max_pool_size | quote }}
+            - name: PASSENGER_REQUEST_QUEUE_OVERFLOW_TO_WAIT_LIST
+              value: {{ .Values.web.passenger_request_queue_overflow_to_wait_list | quote }}
+            - name: PASSENGER_MAX_REQUEST_QUEUE_SIZE
+              value: {{ .Values.web.passenger_max_request_queue_size | quote }}
+            - name: PASSENGER_RESTART_DIR
+              value: "/tmp/passenger-restart"
+            # Nginx compression and buffering
+            - name: NGINX_GZIP
+              value: {{ .Values.web.nginx_gzip | quote }}
+            - name: NGINX_GZIP_COMP_LEVEL
+              value: {{ .Values.web.nginx_gzip_comp_level | quote }}
+            - name: NGINX_GZIP_MIN_LENGTH
+              value: {{ .Values.web.nginx_gzip_min_length | quote }}
+            - name: NGINX_CLIENT_MAX_BODY_SIZE
+              value: {{ .Values.web.nginx_client_max_body_size | quote }}
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_connect_timeout | quote }}
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_send_timeout | quote }}
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: {{ .Values.web.nginx_proxy_read_timeout | quote }}
+            - name: NGINX_PROXY_BUFFERING
+              value: {{ .Values.web.nginx_proxy_buffering | quote }}
+            - name: NGINX_PROXY_BUFFER_SIZE
+              value: {{ .Values.web.nginx_proxy_buffer_size | quote }}
+            - name: NGINX_PROXY_BUFFERS
+              value: {{ .Values.web.nginx_proxy_buffers | quote }}
+            - name: OS_SERVER_HOTFIX_ENFORCE_BATCH_RUN_START
+              value: {{ .Values.server_hotfix.enforceBatchRunStart | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_ENABLED
+              value: {{ .Values.server_hotfix.completedKeyTtlEnabled | quote }}
+            - name: OS_SERVER_HOTFIX_COMPLETED_KEY_TTL_SECONDS
+              value: {{ .Values.server_hotfix.completedKeyTtlSeconds | quote }}
+            - name: OS_SERVER_HOTFIX_AUTOCHAIN_LHS_TO_BATCH_RUN
+              value: {{ .Values.server_hotfix.autochainLhsToBatchRun | quote }}
+          command: ["bash", "-c", "/opt/hotfix/apply-hotfix.sh && /usr/local/bin/rails-entrypoint && /usr/local/bin/start-server & sleep 3 && sed -i 's/^[[:space:]]*gzip off;/    gzip on;/g' /opt/nginx/conf/nginx.conf && sed -i 's/passenger_max_pool_size 16;/passenger_max_pool_size 32;/g' /opt/nginx/conf/nginx.conf && pkill -HUP nginx; wait"]
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep {{ .Values.web.lifecycle.preStopSleepSeconds | quote }}
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    sleep 2
+                    pkill -HUP nginx || true
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.web.readinessProbe.path }}
               port: 80
-            initialDelaySeconds: 60
-            periodSeconds: 200
-            timeoutSeconds: 120
-            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           livenessProbe:
             exec:
-              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
-            initialDelaySeconds: 5
-            periodSeconds: 200
-            timeoutSeconds: 120
-            failureThreshold: 3
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  grep -qs "/mnt/openstudio " /proc/mounts && \
+                  test -w /mnt/openstudio && \
+                  exit 0 || exit 1
+            initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+          {{- if .Values.web.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.web.startupProbe.path }}
+              port: 80
+            initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          {{- end }}
       priorityClassName: high-priority
       volumes:
         - name: nfs
           persistentVolumeClaim:
             claimName: nfs-pvc
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+        {{- if .Values.server_hotfix.enabled }}
+        - name: server-hotfix-scripts
+          configMap:
+            name: server-hotfix-scripts
+            defaultMode: 0755
+        {{- end }}

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -5,21 +5,40 @@
 
 # Set to google, aws, azure, or openstack
 provider:
-  name: ""
+  name: "aws"
 
 cluster:
   name: "openstudio-server-03"
 
+cluster_autoscaler:
+  expander: "least-waste"
+  scanInterval: "10s"
+  maxNodeProvisionTime: "3m"
+  scaleDownUtilizationThreshold: "0.2"
+  scaleDownUnneededTime: "10m"
+  maxGracefulTerminationSec: "120"
+  scaleDownDelayAfterFailure: "5m"
+
 nfs-server-provisioner:
+  service:
+    # Fixed ClusterIP used by RWX mount option `addr=` for Bottlerocket NFS mounts.
+    clusterIP: "10.100.148.127"
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 550Gi
+    size: 2Ti
   storageClass:
-    allowVolumeExpansion: false
+    allowVolumeExpansion: true
     mountOptions:
       - vers=4
-      - sync
+      - addr=10.100.148.127
+  resources:
+    requests:
+      cpu: 4
+      memory: "8Gi"
+    limits:
+      cpu: 8
+      memory: "16Gi"
 db:
   name:  "db"
   label: "db"
@@ -27,9 +46,12 @@ db:
   password: "openstudio"
   container:
     name: "mongo-db"
-    image: "mongo:6.0.7"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/mongo:6.0.7"
     resources:
       requests:
+        cpu: 2
+        memory: "8Gi"
+      limits:
         cpu: 4
         memory: "12Gi"
     ports:
@@ -37,7 +59,7 @@ db:
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -60,7 +82,7 @@ nfs_pvc:
   name: "nfs-pvc"
   accessModes:
     - "ReadWriteMany"
-  storageClass: "ssd"
+  storageClass: "nfs"
   storage: "500Gi"
 
 
@@ -68,19 +90,22 @@ redis:
   name: "redis"
   label: "redis"
   password: "openstudio"
-  maxclients: 40000
+  maxclients: 100000
   container:
     name: "redis"
-    image: "redis:6.0.9"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/redis:6.0.9"
     resources:
       requests:
-        cpu: 3
+        cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
     port: 6379
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -90,17 +115,31 @@ redis_svc:
   port: 6379
   url: "redis://:openstudio@queue:6379"
 
+server_hotfix:
+  enabled: true
+  # Keep starts constrained to known safe analysis types
+  enforceBatchRunStart: true
+  # After an LHS run, automatically enqueue batch_run to submit generated datapoints
+  autochainLhsToBatchRun: true
+  # Replace persistent analysis:<id>:completed key with expiring key
+  completedKeyTtlEnabled: true
+  completedKeyTtlSeconds: 900
+
+
 rserve:
   name: "rserve"
   label: "rserve"
   number_of_workers: "1"
   container:
     name: "rserve"
-    image: "nrel/openstudio-rserve:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-rserve:3.10.0"
     resources:
       requests:
         cpu: 1
-        memory: "1Gi"
+        memory: "2Gi"
+      limits:
+        cpu: 2
+        memory: "4Gi"
 
 rserve_svc:
   name: "rserve"
@@ -113,31 +152,49 @@ web_background:
   replicas: 1
   container:
     name: "web-background"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
         cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
 
 web:
   name: "web"
   label: "web"
   secret_key_value: "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
-  # passenger_max_request_queue_size: "1600"
-  # Use this formula (1024 * memory of web pod in Gi * 0.75) / memory per passenger process
-  # passenger_max_pool_size: "21"
-  # This value is typically between 150 and 400, find this by ssh into web pod and doing `passenger-status`
+  # Passenger tuning parameters
   passenger_memory_per_process: 250
+  passenger_min_instances: 2
+  passenger_max_pool_size: 32
+  passenger_request_queue_overflow_to_wait_list: "true"
+  passenger_max_request_queue_size: 1600
+  # Nginx tuning parameters
+  nginx_gzip: "on"
+  nginx_gzip_comp_level: 6
+  nginx_gzip_min_length: 1024
+  nginx_client_max_body_size: "100m"
+  # Connection timeout for analyses.json download
+  nginx_proxy_connect_timeout: "90s"
+  nginx_proxy_send_timeout: "300s"
+  nginx_proxy_read_timeout: "300s"
+  nginx_proxy_buffering: "on"
+  nginx_proxy_buffer_size: "32k"
+  nginx_proxy_buffers: "8 32k"
+  # Health check tuning
+  health_check_timeout_analyses: 15
   container:
     name: "web"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
-        cpu: 6
-        memory: "50Gi"
-      limits:
         cpu: 8
-        memory: "60Gi"
+        memory: "32Gi"
+      limits:
+        cpu: 12
+        memory: "48Gi"
     port:
      http: 80
      https: 443
@@ -163,17 +220,63 @@ worker:
   label: "worker"
   container:
     name: "worker"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0"
     resources:
       requests:
-        cpu: 500m
+        cpu: 600m
         memory: "1Gi"
+      limits:
+        cpu: 800m
+        memory: "2Gi"
     terminationGracePeriodSeconds: 180
 
 worker_hpa:
   name: "worker"
   minReplicas: 2
-  maxReplicas: 6600
-  targetCPUUtilizationPercentage: 10
-  stabilizationWindowSeconds: 300
-  scalePolicyValue: 950
+  maxReplicas: 15000
+  targetCPUUtilizationPercentage: 35
+  scaleUpStabilizationWindowSeconds: 0
+  scaleDownStabilizationWindowSeconds: 600
+  scaleUpPolicyValue: 500
+  scaleUpPolicyPeriodSeconds: 60
+  scaleDownPolicyValue: 25
+  scaleDownPolicyPeriodSeconds: 60
+
+s3_exporter:
+  enabled: false
+  schedule: "*/5 * * * *"
+  bucket: ""
+  prefix: ""
+  apiBaseUrl: "http://web"
+  nfsRoot: "/mnt/openstudio"
+  includeEnrichArtifacts: false
+  awsCliImage: "public.ecr.aws/aws-cli/aws-cli:2.17.49"
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  activeDeadlineSeconds: 1800
+  storageClass: ""
+  includePatterns:
+    - "manifest/*"
+    - "csv/*"
+  excludePatterns: []
+  serviceAccount:
+    create: true
+    name: "s3-sync-sa"
+    roleArn: ""
+    annotations: {}
+  resources:
+    collector:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+    uploader:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"


### PR DESCRIPTION
## Summary

Adds a hotfix mechanism that applies Ruby patches to the OpenStudio server at pod startup, without requiring a new container image. Useful for applying critical fixes to deployed pods immediately.

## Changes

### server-hotfix-configmap.yaml (new)
ConfigMap mounted at `/opt/hotfix` in `web` and `web-background` pods. Contains:
- `apply-hotfix.sh`: entrypoint that runs patches based on feature flags
- `patch-start-guards.rb`: enforces valid `analysis_type` on start requests, prevents duplicate starts
- `patch-completed-ttl.rb`: replaces persistent Redis `completed` key with TTL-expiring key
- `patch-start-analysis-type-option.rb`: ensures `analysis_type` is preserved in run options
- `patch-lhs-autochain.rb`: auto-enqueues `batch_run` after LHS sample generation

### web-deploy.yaml + web-background-deploy.yaml
- Mount `server-hotfix-scripts` configMap volume at `/opt/hotfix` (readOnly, mode 0755)
- Prefix container command: `/opt/hotfix/apply-hotfix.sh && ...`
- Inject hotfix env vars to pods

## Values Added
```yaml
server_hotfix:
  enabled: true
  enforceBatchRunStart: true       # guard invalid analysis_type starts
  autochainLhsToBatchRun: true     # auto-enqueue batch_run after LHS
  completedKeyTtlEnabled: true     # replace persistent key with TTL key
  completedKeyTtlSeconds: 900      # TTL duration
```

## Disabling
Set `server_hotfix.enabled: false` to skip mounting and applying hotfixes entirely.