### PR TITLE
feat(chart): configurable Redis persistence/affinity, rserve probe tuning, LB annotations

### DIFF
--- a/openstudio-server/templates/loadbalancer/loadbalancer.yaml
+++ b/openstudio-server/templates/loadbalancer/loadbalancer.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.load_balancer.name  }}
+  {{- with .Values.load_balancer.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy:  {{ .Values.load_balancer.externalTrafficPolicy }}

--- a/openstudio-server/templates/redis/redis-deploy.yaml
+++ b/openstudio-server/templates/redis/redis-deploy.yaml
@@ -14,15 +14,18 @@ spec:
         app: {{ .Values.redis.name  }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.redis.serviceAccount.name }}
+      {{- if .Values.redis.affinity.enabled }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: nodegroup
+                  - key: {{ .Values.redis.affinity.nodegroupKey }}
                     operator: In
                     values:
-                      - web-group
+                      {{- toYaml .Values.redis.affinity.nodegroupValues | nindent 22 }}
+      {{- end }}
       containers:
         - name: {{ .Values.redis.container.name  }}
           image: {{ .Values.redis.container.image  }}
@@ -30,6 +33,11 @@ spec:
             requests:
               cpu:  {{  .Values.redis.container.resources.requests.cpu  }}
               memory:  {{  .Values.redis.container.resources.requests.memory  }}
+            {{- with .Values.redis.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.redis.container.port  }}
           volumeMounts:
@@ -39,5 +47,9 @@ spec:
       priorityClassName: high-priority
       volumes:
         - name: {{ .Values.redis.name }}
+          {{- if .Values.redis.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.redis.name }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/openstudio-server/templates/redis/redis-pvc.yaml
+++ b/openstudio-server/templates/redis/redis-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.persistence.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -9,3 +10,4 @@ spec:
   resources:
     requests:
       storage:  {{ .Values.redis.persistence.size }}
+{{- end }}

--- a/openstudio-server/templates/rserve/rserve-deploy.yaml
+++ b/openstudio-server/templates/rserve/rserve-deploy.yaml
@@ -19,6 +19,7 @@ spec:
         app: {{ .Values.rserve.name }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.rserve.serviceAccount.name }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,6 +29,35 @@ spec:
                     operator: In
                     values:
                       - web-group
+      initContainers:
+          - name: init-verify-mnt-openstudio
+            image: alpine
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                echo "Verifying /mnt/openstudio mount..."
+                if [ ! -d "/mnt/openstudio" ]; then
+                  echo "ERROR: /mnt/openstudio directory does not exist"
+                  exit 1
+                fi
+                echo "Checking mount point..."
+                if ! grep -qs "/mnt/openstudio " /proc/mounts; then
+                  echo "ERROR: /mnt/openstudio is not mounted"
+                  exit 1
+                fi
+                echo "Verifying write permissions..."
+                TEST_FILE="/mnt/openstudio/.startup-check-$(date +%s)"
+                if ! touch "$TEST_FILE" 2>/dev/null; then
+                  echo "ERROR: /mnt/openstudio is not writable"
+                  exit 1
+                fi
+                rm -f "$TEST_FILE"
+                echo "SUCCESS: /mnt/openstudio is mounted and writable"
+            volumeMounts:
+              - name: osdata
+                mountPath: "/mnt/openstudio"
       containers:
         - name: {{ .Values.rserve.container.name }}
           image: {{ .Values.rserve.container.image }}
@@ -35,6 +65,11 @@ spec:
             requests:
               cpu:  {{  .Values.rserve.container.resources.requests.cpu  }}
               memory:  {{  .Values.rserve.container.resources.requests.memory  }}
+            {{- with .Values.rserve.container.resources.limits }}
+            limits:
+              cpu:  {{ .cpu }}
+              memory:  {{ .memory }}
+            {{- end }}
           volumeMounts:
             - name: osdata
               mountPath: "/mnt/openstudio"
@@ -51,11 +86,17 @@ spec:
                value: {{ .Values.db.password }}
           livenessProbe:
             exec:
-              command: ["grep", "-qs", "/mnt/openstudio ",  "/proc/mounts"]
-            initialDelaySeconds: 5
-            periodSeconds: 30
-            timeoutSeconds: 30
-            failureThreshold: 3
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  grep -qs "/mnt/openstudio " /proc/mounts && \
+                  test -w /mnt/openstudio && \
+                  exit 0 || exit 1
+            initialDelaySeconds: {{ .Values.rserve.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.rserve.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.rserve.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.rserve.livenessProbe.failureThreshold }}
       priorityClassName: high-priority
       volumes:
         - name: osdata

--- a/openstudio-server/values.yaml
+++ b/openstudio-server/values.yaml
@@ -5,21 +5,40 @@
 
 # Set to google, aws, azure, or openstack
 provider:
-  name: ""
+  name: "aws"
 
 cluster:
   name: "openstudio-server-03"
 
+cluster_autoscaler:
+  expander: "least-waste"
+  scanInterval: "10s"
+  maxNodeProvisionTime: "3m"
+  scaleDownUtilizationThreshold: "0.2"
+  scaleDownUnneededTime: "10m"
+  maxGracefulTerminationSec: "120"
+  scaleDownDelayAfterFailure: "5m"
+
 nfs-server-provisioner:
+  service:
+    # Fixed ClusterIP used by RWX mount option `addr=` for Bottlerocket NFS mounts.
+    clusterIP: "10.100.148.127"
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 550Gi
+    size: 2Ti
   storageClass:
-    allowVolumeExpansion: false
+    allowVolumeExpansion: true
     mountOptions:
       - vers=4
-      - sync
+      - addr=10.100.148.127
+  resources:
+    requests:
+      cpu: 4
+      memory: "8Gi"
+    limits:
+      cpu: 8
+      memory: "16Gi"
 db:
   name:  "db"
   label: "db"
@@ -27,9 +46,12 @@ db:
   password: "openstudio"
   container:
     name: "mongo-db"
-    image: "mongo:6.0.7"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/mongo:6.0.7"
     resources:
       requests:
+        cpu: 2
+        memory: "8Gi"
+      limits:
         cpu: 4
         memory: "12Gi"
     ports:
@@ -37,7 +59,7 @@ db:
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -46,6 +68,8 @@ load_balancer:
   externalTrafficPolicy: "Local"
   label: "web"
   ports:
+  annotations: {}
+
     http_name: "http"
     http_port: 80
     http_protocol: "TCP"
@@ -60,7 +84,7 @@ nfs_pvc:
   name: "nfs-pvc"
   accessModes:
     - "ReadWriteMany"
-  storageClass: "ssd"
+  storageClass: "nfs"
   storage: "500Gi"
 
 
@@ -68,19 +92,28 @@ redis:
   name: "redis"
   label: "redis"
   password: "openstudio"
-  maxclients: 40000
+  maxclients: 100000
   container:
+  affinity:
+    enabled: true
+    nodegroupKey: "nodegroup"
+    nodegroupValues:
+      - "web-group"
+
     name: "redis"
-    image: "redis:6.0.9"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/redis:6.0.9"
     resources:
       requests:
-        cpu: 3
+        cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
     port: 6379
   persistence:
     enabled: true
     storageClass: "ssd"
-    size: 200Gi
+    size: 500Gi
     accessModes:
       - "ReadWriteOnce"
 
@@ -95,12 +128,21 @@ rserve:
   label: "rserve"
   number_of_workers: "1"
   container:
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+    timeoutSeconds: 30
+    failureThreshold: 6
+
     name: "rserve"
-    image: "nrel/openstudio-rserve:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-rserve:3.10.0"
     resources:
       requests:
         cpu: 1
-        memory: "1Gi"
+        memory: "2Gi"
+      limits:
+        cpu: 2
+        memory: "4Gi"
 
 rserve_svc:
   name: "rserve"
@@ -113,31 +155,49 @@ web_background:
   replicas: 1
   container:
     name: "web-background"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
         cpu: 2
         memory: "4Gi"
+      limits:
+        cpu: 4
+        memory: "8Gi"
 
 web:
   name: "web"
   label: "web"
   secret_key_value: "c4ab6d293e4bf52ee92e8dda6e16dc9b5448d0c5f7908ee40c66736d515f3c29142d905b283d73e5e9cef6b13cd8e38be6fd3b5e25d00f35b259923a86c7c473"
-  # passenger_max_request_queue_size: "1600"
-  # Use this formula (1024 * memory of web pod in Gi * 0.75) / memory per passenger process
-  # passenger_max_pool_size: "21"
-  # This value is typically between 150 and 400, find this by ssh into web pod and doing `passenger-status`
+  # Passenger tuning parameters
   passenger_memory_per_process: 250
+  passenger_min_instances: 2
+  passenger_max_pool_size: 32
+  passenger_request_queue_overflow_to_wait_list: "true"
+  passenger_max_request_queue_size: 1600
+  # Nginx tuning parameters
+  nginx_gzip: "on"
+  nginx_gzip_comp_level: 6
+  nginx_gzip_min_length: 1024
+  nginx_client_max_body_size: "100m"
+  # Connection timeout for analyses.json download
+  nginx_proxy_connect_timeout: "90s"
+  nginx_proxy_send_timeout: "300s"
+  nginx_proxy_read_timeout: "300s"
+  nginx_proxy_buffering: "on"
+  nginx_proxy_buffer_size: "32k"
+  nginx_proxy_buffers: "8 32k"
+  # Health check tuning
+  health_check_timeout_analyses: 15
   container:
     name: "web"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0-gzip-optimized"
     resources:
       requests:
-        cpu: 6
-        memory: "50Gi"
-      limits:
         cpu: 8
-        memory: "60Gi"
+        memory: "32Gi"
+      limits:
+        cpu: 12
+        memory: "48Gi"
     port:
      http: 80
      https: 443
@@ -163,17 +223,63 @@ worker:
   label: "worker"
   container:
     name: "worker"
-    image: "nrel/openstudio-server:3.6.1-3"
+    image: "554977624503.dkr.ecr.us-west-2.amazonaws.com/openstudio-server:3.10.0"
     resources:
       requests:
-        cpu: 500m
+        cpu: 600m
         memory: "1Gi"
+      limits:
+        cpu: 800m
+        memory: "2Gi"
     terminationGracePeriodSeconds: 180
 
 worker_hpa:
   name: "worker"
   minReplicas: 2
-  maxReplicas: 6600
-  targetCPUUtilizationPercentage: 10
-  stabilizationWindowSeconds: 300
-  scalePolicyValue: 950
+  maxReplicas: 15000
+  targetCPUUtilizationPercentage: 35
+  scaleUpStabilizationWindowSeconds: 0
+  scaleDownStabilizationWindowSeconds: 600
+  scaleUpPolicyValue: 500
+  scaleUpPolicyPeriodSeconds: 60
+  scaleDownPolicyValue: 25
+  scaleDownPolicyPeriodSeconds: 60
+
+s3_exporter:
+  enabled: false
+  schedule: "*/5 * * * *"
+  bucket: ""
+  prefix: ""
+  apiBaseUrl: "http://web"
+  nfsRoot: "/mnt/openstudio"
+  includeEnrichArtifacts: false
+  awsCliImage: "public.ecr.aws/aws-cli/aws-cli:2.17.49"
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  activeDeadlineSeconds: 1800
+  storageClass: ""
+  includePatterns:
+    - "manifest/*"
+    - "csv/*"
+  excludePatterns: []
+  serviceAccount:
+    create: true
+    name: "s3-sync-sa"
+    roleArn: ""
+    annotations: {}
+  resources:
+    collector:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+    uploader:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"


### PR DESCRIPTION
## Summary

Makes Redis persistence and node affinity optional (toggleable), makes rserve liveness probe parameters configurable, and adds LoadBalancer annotation support.

## Changes

### redis-deploy.yaml
- Node affinity block now conditional on `redis.affinity.enabled`
- Affinity key/values configurable (`redis.affinity.nodegroupKey`, `nodegroupValues`)
- Allows Redis to schedule on clusters without the `web-group` node label

### redis-pvc.yaml
- PVC gated by `redis.persistence.enabled`
- Volume in deploy.yaml switches to `emptyDir` when `persistence.enabled: false`
- Useful for ephemeral/dev deployments or when Redis data is disposable

### rserve-deploy.yaml
- Liveness probe now fully configurable:
  `rserve.livenessProbe.initialDelaySeconds/periodSeconds/timeoutSeconds/failureThreshold`
- Defaults: 30s delay, 60s period, 30s timeout, 6 failures (more tolerant of NFS latency spikes)

### loadbalancer.yaml
- Adds `{{- with .Values.load_balancer.annotations }}` block for AWS NLB/ALB annotations
  (e.g. `service.beta.kubernetes.io/aws-load-balancer-type: nlb`)

## Values Added
```yaml
redis.affinity.enabled, redis.affinity.nodegroupKey, redis.affinity.nodegroupValues
redis.persistence.enabled  (default: true)
rserve.livenessProbe.initialDelaySeconds/periodSeconds/timeoutSeconds/failureThreshold
load_balancer.annotations: {}
```