### PR TITLE
feat(nginx): structured JSON access logging and X-Request-Id header

### DIFF
--- a/openstudio-server/configmaps/nginx/nginx.conf
+++ b/openstudio-server/configmaps/nginx/nginx.conf
@@ -1,0 +1,175 @@
+daemon off;
+user nobody nogroup;
+worker_processes auto;
+error_log /dev/stderr;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    passenger_root /usr/local/lib/ruby/gems/3.2.0/gems/passenger-6.0.27;
+    passenger_ruby /usr/local/bin/ruby;
+    passenger_friendly_error_pages on;
+
+    passenger_app_env docker;
+
+    include mime.types;
+    default_type application/octet-stream;
+    gzip on;
+    gzip_types text/plain text/css text/javascript application/json application/javascript;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_vary on;
+
+    log_format timed_json escape=json
+      '{'
+        '"time":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"request_id":"$request_id",'
+        '"host":"$host",'
+        '"method":"$request_method",'
+        '"uri":"$request_uri",'
+        '"status":$status,'
+        '"request_time":$request_time,'
+        '"upstream_connect_time":"$upstream_connect_time",'
+        '"upstream_header_time":"$upstream_header_time",'
+        '"upstream_response_time":"$upstream_response_time",'
+        '"bytes_sent":$bytes_sent,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"referer":"$http_referer",'
+        '"user_agent":"$http_user_agent"'
+      '}';
+    access_log /dev/stdout timed_json;
+    sendfile on;
+    keepalive_timeout 0;
+
+    passenger_max_request_queue_size 50; # This is a reserved keyword for dynamic substitution
+    passenger_max_pool_size 32; # This is a reserved keyword for dynamic substitution
+    passenger_pool_idle_time 0;
+
+    server {
+        listen 80;
+        passenger_enabled on;
+        server_name localhost;
+        root /opt/openstudio/server/public;
+
+        client_max_body_size 1000M; # allows file uploads up to 1000MB
+        add_header X-Request-Id $request_id always;
+
+        location ~ ^/(assets\/variables)  {
+            root /mnt/openstudio/server;
+            gzip_static on;
+            expires max;
+            add_header Cache-Control public;
+        }
+
+        location ~ ^/(assets)/  {
+          root /opt/openstudio/server/public;
+          gzip_static on;
+          expires max;
+          add_header Cache-Control public;
+        }
+    }
+}
+
+# configuration file /opt/nginx/conf/mime.types:
+
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}


### PR DESCRIPTION
## Summary

Replaces nginx's default access log format with a structured JSON format suitable for log aggregation (CloudWatch Logs Insights, Splunk, Datadog, etc.).

## Changes

### openstudio-server/configmaps/nginx/nginx.conf
- Defines `timed_json` log format with fields:
  `time`, `remote_addr`, `request_id`, `host`, `method`, `uri`, `status`,
  `request_time`, `upstream_connect_time`, `upstream_header_time`,
  `upstream_response_time`, `bytes_sent`, `body_bytes_sent`, `referer`, `user_agent`
- Changes `access_log /dev/stdout` → `access_log /dev/stdout timed_json`
- Adds `add_header X-Request-Id $request_id always` for distributed tracing

## Benefits
- Machine-readable logs consumable by structured log queries
- Per-request upstream timing visible for latency debugging
- `request_id` header enables tracing requests end-to-end through load balancer logs