### PR TITLE
feat(ops): queue autoscaler, staged ramp, stalled analysis remediation, CNI restart recovery

### DIFF
--- a/scripts/clean-data.sh
+++ b/scripts/clean-data.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Clean OpenStudio Server: Delete projects, analyses, and associated data to start fresh
+# This script deletes database data, clears Redis, and optionally wipes persistent volumes
+# WARNING: This is destructive and cannot be undone!
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openstudio-server}"
+DRY_RUN=false
+DELETE_PVS=false
+FORCE=false
+REDIS_PASSWORD="${REDIS_PASSWORD:-openstudio}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  clean-data.sh [options]
+
+Description:
+  Deletes projects, analyses, and associated data from the OpenStudio Server cluster.
+  This includes:
+    - PostgreSQL database data (projects, analyses, results)
+    - Redis cache
+    - NFS shared filesystem data (optionally)
+    - Persistent volumes (optionally)
+
+Options:
+  -n, --namespace <name>      Kubernetes namespace (default: openstudio-server)
+  --dry-run                   Show what would be deleted without making changes
+  --delete-pvs                Also delete persistent volume claims (destructive!)
+  -f, --force                 Skip confirmation prompts
+  -h, --help                  Show this help text
+
+Examples:
+  # Preview what would be deleted (safe)
+  ./clean-data.sh --dry-run
+
+  # Delete database and Redis data, keep volumes
+  ./clean-data.sh
+
+  # Delete everything including volumes
+  ./clean-data.sh --delete-pvs
+
+  # Skip all prompts
+  ./clean-data.sh -f
+
+USAGE
+}
+
+log_info() {
+  echo "[INFO] $*"
+}
+
+log_warn() {
+  echo "[WARN] $*" >&2
+}
+
+log_error() {
+  echo "[ERROR] $*" >&2
+}
+
+confirm() {
+  local prompt="$1"
+  
+  if [[ "${FORCE}" == "true" ]]; then
+    return 0
+  fi
+  
+  local response
+  read -p "${prompt} (yes/no): " response
+  [[ "${response}" == "yes" ]]
+}
+
+check_kubectl() {
+  if ! command -v kubectl &> /dev/null; then
+    log_error "kubectl not found. Please install kubectl."
+    exit 1
+  fi
+  
+  if ! kubectl cluster-info &> /dev/null; then
+    log_error "Not connected to a Kubernetes cluster."
+    exit 1
+  fi
+}
+
+check_namespace() {
+  if ! kubectl get namespace "${NAMESPACE}" &> /dev/null; then
+    log_error "Namespace '${NAMESPACE}' does not exist."
+    exit 1
+  fi
+}
+
+get_pod_by_label() {
+  local label="$1"
+  kubectl -n "${NAMESPACE}" get pods \
+    -l "${label}" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | awk '{print $1}'
+}
+
+get_pod_by_any_label() {
+  local pod=""
+  local label
+  for label in "$@"; do
+    pod="$(get_pod_by_label "${label}")"
+    if [[ -n "${pod}" ]]; then
+      echo "${pod}"
+      return 0
+    fi
+  done
+  echo ""
+}
+
+exec_in_pod() {
+  local pod="$1"
+  local cmd="$2"
+  
+  if [[ -z "${pod}" ]]; then
+    log_warn "Pod not found for command: ${cmd}"
+    return 1
+  fi
+  
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log_info "[DRY RUN] Would execute in pod ${pod}: ${cmd}"
+    return 0
+  fi
+  
+  kubectl -n "${NAMESPACE}" exec "${pod}" -- bash -c "${cmd}"
+}
+
+clean_database() {
+  log_info "Cleaning database..."
+  
+  local db_pod
+  db_pod=$(get_pod_by_any_label \
+    "app.kubernetes.io/name=openstudio-server,app.kubernetes.io/component=db" \
+    "app=db")
+  
+  if [[ -z "${db_pod}" ]]; then
+    log_warn "Database pod not found. Skipping database cleanup."
+    return
+  fi
+  
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log_info "[DRY RUN] Would drop all non-system MongoDB databases"
+    return
+  fi
+  
+  log_info "Dropping non-system MongoDB databases..."
+  exec_in_pod "${db_pod}" "mongosh \
+    -u \"\$MONGO_INITDB_ROOT_USERNAME\" \
+    -p \"\$MONGO_INITDB_ROOT_PASSWORD\" \
+    --authenticationDatabase admin \
+    --quiet \
+    --eval '
+      const protectedDbs = new Set([\"admin\", \"config\", \"local\"]);
+      const dbs = db.adminCommand({ listDatabases: 1 }).databases.map(d => d.name);
+      dbs.filter(name => !protectedDbs.has(name)).forEach(dbName => {
+        const result = db.getSiblingDB(dbName).dropDatabase();
+        print(\"Dropped \" + dbName + \": \" + (result.ok === 1 ? \"ok\" : tojson(result)));
+      });
+    '"
+  
+  log_info "Database cleanup complete."
+}
+
+clean_redis() {
+  log_info "Cleaning Redis cache..."
+  
+  local redis_pod
+  redis_pod=$(get_pod_by_any_label \
+    "app.kubernetes.io/name=openstudio-server,app.kubernetes.io/component=redis" \
+    "app=redis")
+  
+  if [[ -z "${redis_pod}" ]]; then
+    log_warn "Redis pod not found. Skipping Redis cleanup."
+    return
+  fi
+  
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log_info "[DRY RUN] Would flush all Redis data"
+    return
+  fi
+  
+  if exec_in_pod "${redis_pod}" "redis-cli -a \"${REDIS_PASSWORD}\" FLUSHALL"; then
+    log_info "Redis cache cleared."
+  else
+    log_error "Failed to flush Redis cache."
+    return 1
+  fi
+}
+
+clean_nfs_data() {
+  log_info "Cleaning NFS shared filesystem..."
+  
+  local nfs_pod
+  nfs_pod=$(get_pod_by_any_label \
+    "app.kubernetes.io/name=openstudio-server,app.kubernetes.io/component=web" \
+    "app=web")
+  
+  if [[ -z "${nfs_pod}" ]]; then
+    log_warn "Web pod not found. Skipping NFS cleanup."
+    return
+  fi
+  
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log_info "[DRY RUN] Would delete NFS data directories"
+    return
+  fi
+  
+  # Remove analysis results and project files
+  exec_in_pod "${nfs_pod}" "rm -rf /mnt/openstudio/projects /mnt/openstudio/analyses 2>/dev/null || true"
+  
+  # Ensure directories exist for fresh start
+  exec_in_pod "${nfs_pod}" "mkdir -p /mnt/openstudio/projects /mnt/openstudio/analyses"
+  
+  log_info "NFS shared filesystem cleaned."
+}
+
+list_pvcs() {
+  log_info "Persistent Volume Claims in namespace '${NAMESPACE}':"
+  kubectl -n "${NAMESPACE}" get pvc -o wide
+}
+
+delete_pvcs() {
+  log_info "Deleting Persistent Volume Claims..."
+  
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log_info "[DRY RUN] Would delete the following PVCs:"
+    list_pvcs
+    return
+  fi
+  
+  local pvcs
+  pvcs=$(kubectl -n "${NAMESPACE}" get pvc -o jsonpath='{.items[*].metadata.name}')
+  
+  if [[ -z "${pvcs}" ]]; then
+    log_info "No PVCs found."
+    return
+  fi
+  
+  for pvc in ${pvcs}; do
+    log_info "Deleting PVC: ${pvc}"
+    kubectl -n "${NAMESPACE}" delete pvc "${pvc}" --ignore-not-found=true
+  done
+  
+  # Wait for PVs to be deleted
+  log_info "Waiting for persistent volumes to be released..."
+  sleep 5
+  
+  log_info "Persistent volumes deleted."
+}
+
+main() {
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -n|--namespace)
+        NAMESPACE="$2"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --delete-pvs)
+        DELETE_PVS=true
+        shift
+        ;;
+      -f|--force)
+        FORCE=true
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        log_error "Unknown argument: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+  
+  # Validate environment
+  check_kubectl
+  check_namespace
+  
+  log_info "OpenStudio Server Data Cleanup Script"
+  log_info "========================================"
+  log_info "Namespace: ${NAMESPACE}"
+  
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log_warn "DRY RUN MODE - No changes will be made"
+  fi
+  
+  echo ""
+  
+  # Show what will be deleted
+  log_info "This script will delete:"
+  echo "  - All projects and analyses from MongoDB"
+  echo "  - All data points and results"
+  echo "  - Redis cache"
+  echo "  - Analysis and project files from NFS"
+  
+  if [[ "${DELETE_PVS}" == "true" ]]; then
+    echo "  - All Persistent Volume Claims (DESTRUCTIVE!)"
+  fi
+  
+  echo ""
+  
+  if ! confirm "⚠️  Are you absolutely sure you want to proceed?"; then
+    log_info "Cleanup cancelled."
+    exit 0
+  fi
+  
+  if [[ "${DELETE_PVS}" == "true" ]] && ! confirm "⚠️  Delete PVCs? This will destroy persistent volumes."; then
+    DELETE_PVS=false
+    log_info "PVC deletion skipped."
+  fi
+  
+  echo ""
+  
+  # Perform cleanup
+  clean_database
+  clean_redis
+  clean_nfs_data
+  
+  if [[ "${DELETE_PVS}" == "true" ]]; then
+    delete_pvcs
+  else
+    log_info "Persistent volumes retained. Run with --delete-pvs to remove them."
+  fi
+  
+  echo ""
+  
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log_info "Dry run complete. No changes were made."
+  else
+    log_info "✓ Cleanup complete! Database and cache have been cleared."
+    log_info "The system is ready to accept new projects and analyses."
+  fi
+}
+
+main "$@"

--- a/scripts/health-remediation-loop.sh
+++ b/scripts/health-remediation-loop.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openstudio-server}"
+RELEASE="${RELEASE:-openstudio-server}"
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-900}"
+ONCE="${ONCE:-0}"
+LOG_FILE="${LOG_FILE:-./health-remediation-${RELEASE}-$(date +%Y%m%d-%H%M%S).log}"
+ESCALATION_EMAIL="${ESCALATION_EMAIL:-}"
+MAX_REMEDIATIONS_PER_CYCLE="${MAX_REMEDIATIONS_PER_CYCLE:-5}"
+STATE_DIR="${STATE_DIR:-./.health-remediation-state}"
+MAX_UNCORDONS_PER_CYCLE="${MAX_UNCORDONS_PER_CYCLE:-2}"
+MAX_CNI_RESTARTS_PER_CYCLE="${MAX_CNI_RESTARTS_PER_CYCLE:-2}"
+CNI_RESTART_COOLDOWN_SECONDS="${CNI_RESTART_COOLDOWN_SECONDS:-900}"
+CNI_POD_LABEL_SELECTOR="${CNI_POD_LABEL_SELECTOR:-k8s-app=aws-node}"
+SAFE_WORKER_MAX_REPLICAS="${SAFE_WORKER_MAX_REPLICAS:-15000}"
+SAFE_WORKER_CPU_TARGET="${SAFE_WORKER_CPU_TARGET:-35}"
+SAFE_WORKER_SCALE_UP_POLICY="${SAFE_WORKER_SCALE_UP_POLICY:-200}"
+SAFE_WORKER_SCALE_DOWN_POLICY="${SAFE_WORKER_SCALE_DOWN_POLICY:-10}"
+SAFE_WORKER_SCALE_UP_WINDOW_SECONDS="${SAFE_WORKER_SCALE_UP_WINDOW_SECONDS:-0}"
+SAFE_WORKER_SCALE_DOWN_WINDOW_SECONDS="${SAFE_WORKER_SCALE_DOWN_WINDOW_SECONDS:-900}"
+SAFE_WORKER_MEMORY_REQUEST="${SAFE_WORKER_MEMORY_REQUEST:-1Gi}"
+SAFE_WORKER_MEMORY_LIMIT="${SAFE_WORKER_MEMORY_LIMIT:-2Gi}"
+SAFE_WORKER_TERMINATION_GRACE="${SAFE_WORKER_TERMINATION_GRACE:-180}"
+ENFORCE_WORKER_HPA_MAX_REPLICAS="${ENFORCE_WORKER_HPA_MAX_REPLICAS:-0}"
+
+mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR"
+
+log() {
+  printf '%s %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG_FILE"
+}
+
+escalate() {
+  local subject="$1"
+  local body="$2"
+
+  log "ESCALATE: $subject"
+  {
+    printf '\n--- ESCALATION ---\n'
+    printf 'Subject: %s\n' "$subject"
+    printf '%s\n' "$body"
+    printf '--- END ESCALATION ---\n'
+  } | tee -a "$LOG_FILE"
+
+  if [[ -n "$ESCALATION_EMAIL" ]] && command -v mail >/dev/null 2>&1; then
+    printf '%s\n' "$body" | mail -s "$subject" "$ESCALATION_EMAIL"
+  fi
+}
+
+patch_rollout() {
+  local kind="$1"
+  local name="$2"
+  local reason="$3"
+  local timestamp
+  timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+  kubectl -n "$NAMESPACE" patch "$kind" "$name" --type merge -p "$(cat <<EOF
+{"spec":{"template":{"metadata":{"annotations":{"health-remediation.openstudio.io/last-remediated-at":"$timestamp","health-remediation.openstudio.io/reason":"$reason"}}}}}
+EOF
+)" >>"$LOG_FILE" 2>&1
+}
+
+record_state() {
+  local key="$1"
+  local value="$2"
+  printf '%s\n' "$value" >"$STATE_DIR/$key.state"
+}
+
+read_state() {
+  local key="$1"
+  if [[ -f "$STATE_DIR/$key.state" ]]; then
+    cat "$STATE_DIR/$key.state"
+  fi
+}
+
+now_epoch() {
+  date +%s
+}
+
+is_deadline_exceeded_sandbox_error() {
+  local pod_name="$1"
+  local details
+  details="$(kubectl -n "$NAMESPACE" describe pod "$pod_name" 2>>"$LOG_FILE" || true)"
+  grep -qiE '(FailedCreatePodSandBox|Failed to create pod sandbox)' <<<"$details" &&
+    grep -qiE '(DeadlineExceeded|context deadline exceeded)' <<<"$details"
+}
+
+get_cni_pod_for_node() {
+  local node_name="$1"
+  kubectl -n kube-system get pods \
+    -l "$CNI_POD_LABEL_SELECTOR" \
+    --field-selector "spec.nodeName=$node_name" \
+    -o jsonpath='{.items[0].metadata.name}' 2>>"$LOG_FILE" || true
+}
+
+remediate_pod_sandbox_timeouts() {
+  local pod_lines cni_restarts=0
+  pod_lines="$(kubectl -n "$NAMESPACE" get pods -l "release=$RELEASE" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.status.phase}{"|"}{.spec.nodeName}{"\n"}{end}' 2>>"$LOG_FILE" || true)"
+  [[ -z "$pod_lines" ]] && return 0
+
+  while IFS='|' read -r pod_name phase node_name; do
+    [[ -z "$pod_name" ]] && continue
+    [[ "$phase" != "Pending" ]] && continue
+    [[ -z "$node_name" ]] && continue
+
+    if ! is_deadline_exceeded_sandbox_error "$pod_name"; then
+      continue
+    fi
+
+    if [[ "$cni_restarts" -ge "$MAX_CNI_RESTARTS_PER_CYCLE" ]]; then
+      log "CNI restart cap reached ($MAX_CNI_RESTARTS_PER_CYCLE); leaving remaining sandbox timeouts for next cycle"
+      break
+    fi
+
+    local state_key="cni-restart-${node_name//\//-}" last_restart now restart_age cni_pod
+    now="$(now_epoch)"
+    last_restart="$(read_state "$state_key" || true)"
+    if [[ -n "$last_restart" && "$last_restart" =~ ^[0-9]+$ ]]; then
+      restart_age=$((now - last_restart))
+      if (( restart_age < CNI_RESTART_COOLDOWN_SECONDS )); then
+        log "Skipping CNI restart on node/$node_name due to cooldown (${restart_age}s < ${CNI_RESTART_COOLDOWN_SECONDS}s)"
+        continue
+      fi
+    fi
+
+    cni_pod="$(get_cni_pod_for_node "$node_name")"
+    if [[ -z "$cni_pod" ]]; then
+      escalate \
+        "CNI pod not found on node $node_name" \
+        "Pod $pod_name has FailedCreatePodSandBox with DeadlineExceeded on node $node_name, but no CNI pod matched selector '$CNI_POD_LABEL_SELECTOR' in kube-system."
+      continue
+    fi
+
+    log "Remediating pod sandbox timeout for $pod_name on node/$node_name by restarting kube-system/$cni_pod"
+    kubectl -n kube-system delete pod "$cni_pod" >>"$LOG_FILE" 2>&1 || true
+    record_state "$state_key" "$now"
+    cni_restarts=$((cni_restarts + 1))
+  done <<<"$pod_lines"
+}
+
+check_cluster() {
+  log "Checking cluster reachability"
+  if ! kubectl get nodes >>"$LOG_FILE" 2>&1; then
+    escalate \
+      "Cluster unreachable" \
+      "kubectl cannot reach the cluster. The loop did not attempt remediation because this is a control-plane or connectivity issue."
+    return 1
+  fi
+
+  local not_ready
+  not_ready="$(kubectl get nodes --no-headers | awk '$2 !~ /Ready/ {print $1" "$2}')"
+  if [[ -n "$not_ready" ]]; then
+    escalate \
+      "Cluster nodes not ready" \
+      "These nodes are not Ready:\n$not_ready\nManual investigation required."
+    return 1
+  fi
+}
+
+check_release_objects() {
+  local deployments
+  deployments="$(kubectl -n "$NAMESPACE" get deployment -l "release=$RELEASE" --no-headers -o custom-columns=NAME:.metadata.name 2>>"$LOG_FILE" || true)"
+  if [[ -z "$deployments" ]]; then
+    escalate \
+      "No release deployments found" \
+      "No deployments were found in namespace '$NAMESPACE' for release '$RELEASE'."
+    return 1
+  fi
+}
+
+remediate_pod() {
+  local pod_name="$1"
+  local app_name="$2"
+  local status="$3"
+
+  case "$status" in
+    ImagePullBackOff|ErrImagePull|CreateContainerConfigError)
+      escalate \
+        "Image/config issue in $app_name" \
+        "Pod $pod_name is in '$status'. Restarting will not fix an image tag, registry, or configuration problem reliably."
+      return 1
+      ;;
+    Pending|Unknown|CrashLoopBackOff|Error|Init:* )
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  local state_key="${app_name//\//-}"
+  local previous
+  previous="$(read_state "$state_key" || true)"
+  if [[ "${previous:-0}" -ge 1 ]]; then
+    escalate \
+      "Persistent unhealthy pod for $app_name" \
+      "Pod $pod_name is still unhealthy after a prior remediation attempt. Please inspect '$NAMESPACE/$app_name'."
+    return 1
+  fi
+
+  log "Patching deployment/$app_name to trigger a safe rollout"
+  patch_rollout deployment "$app_name" "pod-$status"
+  record_state "$state_key" 1
+}
+
+remediate_scheduling_disabled_nodes() {
+  local uncordoned=0
+  local nodes
+  nodes="$(kubectl get nodes --no-headers | awk '$2 ~ /Ready,SchedulingDisabled/ {print $1}' || true)"
+  [[ -z "$nodes" ]] && return 0
+
+  while IFS= read -r node_name; do
+    [[ -z "$node_name" ]] && continue
+    if [[ "$uncordoned" -ge "$MAX_UNCORDONS_PER_CYCLE" ]]; then
+      break
+    fi
+    log "Uncordoning node $node_name (Ready,SchedulingDisabled)"
+    kubectl uncordon "$node_name" >>"$LOG_FILE" 2>&1 || true
+    uncordoned=$((uncordoned + 1))
+  done <<<"$nodes"
+}
+
+remediate_worker_hpa_profile() {
+  local hpa_name="worker-hpa"
+  local max_replicas cpu_target desired_max desired_cpu
+  max_replicas="$(kubectl -n "$NAMESPACE" get hpa "$hpa_name" -o jsonpath='{.spec.maxReplicas}' 2>>"$LOG_FILE" || true)"
+  cpu_target="$(kubectl -n "$NAMESPACE" get hpa "$hpa_name" -o jsonpath='{.spec.metrics[0].resource.target.averageUtilization}' 2>>"$LOG_FILE" || true)"
+
+  if [[ -z "$max_replicas" || -z "$cpu_target" ]]; then
+    return 0
+  fi
+
+  desired_max="$max_replicas"
+  desired_cpu="$cpu_target"
+
+  if [[ "$ENFORCE_WORKER_HPA_MAX_REPLICAS" == "1" && "$max_replicas" -lt "$SAFE_WORKER_MAX_REPLICAS" ]]; then
+    desired_max="$SAFE_WORKER_MAX_REPLICAS"
+  fi
+  if [[ "$cpu_target" -gt "$SAFE_WORKER_CPU_TARGET" ]]; then
+    desired_cpu="$SAFE_WORKER_CPU_TARGET"
+  fi
+
+  if [[ "$desired_max" == "$max_replicas" && "$desired_cpu" == "$cpu_target" ]]; then
+    return 0
+  fi
+
+  log "Patching hpa/$hpa_name to safe scaling profile (max=$desired_max cpu=$desired_cpu)"
+  kubectl -n "$NAMESPACE" patch hpa "$hpa_name" --type merge -p "$(cat <<EOF
+{"spec":{"minReplicas":2,"maxReplicas":$desired_max,"metrics":[{"type":"Resource","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":$desired_cpu}}}],"behavior":{"scaleUp":{"stabilizationWindowSeconds":$SAFE_WORKER_SCALE_UP_WINDOW_SECONDS,"policies":[{"type":"Pods","value":$SAFE_WORKER_SCALE_UP_POLICY,"periodSeconds":60}]},"scaleDown":{"stabilizationWindowSeconds":$SAFE_WORKER_SCALE_DOWN_WINDOW_SECONDS,"policies":[{"type":"Pods","value":$SAFE_WORKER_SCALE_DOWN_POLICY,"periodSeconds":60}]}}}}
+EOF
+)" >>"$LOG_FILE" 2>&1
+}
+
+remediate_worker_resources() {
+  local mem_req mem_lim grace
+  mem_req="$(kubectl -n "$NAMESPACE" get deployment worker -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' 2>>"$LOG_FILE" || true)"
+  mem_lim="$(kubectl -n "$NAMESPACE" get deployment worker -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}' 2>>"$LOG_FILE" || true)"
+  grace="$(kubectl -n "$NAMESPACE" get deployment worker -o jsonpath='{.spec.template.spec.terminationGracePeriodSeconds}' 2>>"$LOG_FILE" || true)"
+
+  if [[ "$mem_req" == "$SAFE_WORKER_MEMORY_REQUEST" && "$mem_lim" == "$SAFE_WORKER_MEMORY_LIMIT" && "$grace" == "$SAFE_WORKER_TERMINATION_GRACE" ]]; then
+    return 0
+  fi
+
+  log "Patching deployment/worker resources and termination grace (request=$SAFE_WORKER_MEMORY_REQUEST limit=$SAFE_WORKER_MEMORY_LIMIT grace=${SAFE_WORKER_TERMINATION_GRACE}s)"
+  kubectl -n "$NAMESPACE" patch deployment worker --type json -p "$(cat <<EOF
+[{"op":"replace","path":"/spec/template/spec/terminationGracePeriodSeconds","value":$SAFE_WORKER_TERMINATION_GRACE},{"op":"replace","path":"/spec/template/spec/containers/0/resources/requests/memory","value":"$SAFE_WORKER_MEMORY_REQUEST"},{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"$SAFE_WORKER_MEMORY_LIMIT"}]
+EOF
+)" >>"$LOG_FILE" 2>&1
+}
+
+check_pods() {
+  local pod_lines unhealthy_count=0 remediation_count=0
+  pod_lines="$(kubectl -n "$NAMESPACE" get pods -l "release=$RELEASE" --no-headers 2>>"$LOG_FILE" || true)"
+
+  if [[ -z "$pod_lines" ]]; then
+    escalate \
+      "No pods found for release" \
+      "No pods were returned for release '$RELEASE' in namespace '$NAMESPACE'."
+    return 1
+  fi
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    local pod_name ready status restarts age app_name
+    pod_name="$(awk '{print $1}' <<<"$line")"
+    ready="$(awk '{print $2}' <<<"$line")"
+    status="$(awk '{print $3}' <<<"$line")"
+    restarts="$(awk '{print $4}' <<<"$line")"
+    app_name="$(kubectl -n "$NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.labels.app}' 2>>"$LOG_FILE" || true)"
+    app_name="${app_name:-$pod_name}"
+
+    if [[ "$ready" != "1/1" && "$status" != "Completed" ]] || [[ "$status" != "Running" && "$status" != "Completed" ]]; then
+      unhealthy_count=$((unhealthy_count + 1))
+      log "Unhealthy pod detected: $pod_name ready=$ready status=$status restarts=$restarts app=$app_name"
+      if ! remediate_pod "$pod_name" "$app_name" "$status"; then
+        return 1
+      fi
+      remediation_count=$((remediation_count + 1))
+      if [[ "$remediation_count" -ge "$MAX_REMEDIATIONS_PER_CYCLE" ]]; then
+        escalate \
+          "Remediation cap reached" \
+          "The loop hit the per-cycle remediation cap ($MAX_REMEDIATIONS_PER_CYCLE). Remaining issues require manual review."
+        return 1
+      fi
+    fi
+  done <<<"$pod_lines"
+
+  if [[ "$unhealthy_count" -eq 0 ]]; then
+    log "All release pods are healthy"
+  fi
+}
+
+check_hpas() {
+  local hpa_lines missing_hpas
+  hpa_lines="$(kubectl -n "$NAMESPACE" get hpa --no-headers 2>>"$LOG_FILE" || true)"
+  if [[ -z "$hpa_lines" ]]; then
+    escalate \
+      "No HPAs found" \
+      "No HPA objects were found in namespace '$NAMESPACE'."
+    return 1
+  fi
+
+  missing_hpas=""
+  if ! grep -qE '^[[:space:]]*web[[:space:]]' <<<"$hpa_lines"; then
+    missing_hpas="${missing_hpas} web"
+  fi
+  if ! grep -qE '^[[:space:]]*worker-hpa[[:space:]]' <<<"$hpa_lines"; then
+    missing_hpas="${missing_hpas} worker-hpa"
+  fi
+
+  if [[ -n "$missing_hpas" ]]; then
+    escalate \
+      "Missing expected HPA objects" \
+      "Expected HPA objects were not found:$missing_hpas"
+    return 1
+  fi
+
+  log "HPA objects present"
+}
+
+cycle() {
+  log "Starting health cycle for release=$RELEASE namespace=$NAMESPACE"
+  check_cluster
+  check_release_objects
+  remediate_scheduling_disabled_nodes
+  remediate_pod_sandbox_timeouts
+  remediate_worker_hpa_profile
+  remediate_worker_resources
+  check_pods
+  check_hpas
+  log "Health cycle complete"
+}
+
+main() {
+  log "Health-remediation loop starting"
+  log "Prompt summary: check cluster and release every 15 minutes, prefer kubectl patch for safe rollouts, escalate by email when repair is unsafe."
+
+  while true; do
+    if ! cycle; then
+      log "Cycle ended with escalation or failure"
+    fi
+
+    if [[ "$ONCE" == "1" ]]; then
+      break
+    fi
+
+    log "Sleeping for ${INTERVAL_SECONDS}s"
+    sleep "$INTERVAL_SECONDS"
+  done
+}
+
+main "$@"

--- a/scripts/queue-autoscale-loop.sh
+++ b/scripts/queue-autoscale-loop.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openstudio-server}"
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-30}"
+ONCE="${ONCE:-0}"
+LOG_FILE="${LOG_FILE:-./queue-autoscale-${NAMESPACE}-$(date +%Y%m%d-%H%M%S).log}"
+
+REDIS_LABEL_SELECTOR="${REDIS_LABEL_SELECTOR:-app=redis}"
+REDIS_CONTAINER_NAME="${REDIS_CONTAINER_NAME:-redis}"
+REDIS_PASSWORD="${REDIS_PASSWORD:-openstudio}"
+SIMULATIONS_QUEUE="${SIMULATIONS_QUEUE:-resque:queue:simulations}"
+ANALYSES_QUEUE="${ANALYSES_QUEUE:-resque:queue:analyses}"
+REQUEUED_QUEUE="${REQUEUED_QUEUE:-resque:queue:requeued}"
+
+WEB_BACKGROUND_DEPLOYMENT="${WEB_BACKGROUND_DEPLOYMENT:-web-background}"
+MANAGE_WEB_BACKGROUND="${MANAGE_WEB_BACKGROUND:-1}"
+WEB_BACKGROUND_MIN_REPLICAS="${WEB_BACKGROUND_MIN_REPLICAS:-1}"
+WEB_BACKGROUND_MAX_REPLICAS="${WEB_BACKGROUND_MAX_REPLICAS:-12}"
+ANALYSES_PER_WEB_BACKGROUND="${ANALYSES_PER_WEB_BACKGROUND:-50}"
+SIM_LOW_WATERMARK="${SIM_LOW_WATERMARK:-500}"
+BOOST_WEB_BACKGROUND_WHEN_LOW_SIMS="${BOOST_WEB_BACKGROUND_WHEN_LOW_SIMS:-1}"
+LOW_SIM_QUEUE_WEB_BACKGROUND_BOOST="${LOW_SIM_QUEUE_WEB_BACKGROUND_BOOST:-1}"
+
+WORKER_HPA_NAME="${WORKER_HPA_NAME:-worker-hpa}"
+WORKER_LABEL_SELECTOR="${WORKER_LABEL_SELECTOR:-app=worker}"
+WORKER_MIN_REPLICAS_FLOOR="${WORKER_MIN_REPLICAS_FLOOR:-2}"
+WORKER_MIN_REPLICAS_CEILING="${WORKER_MIN_REPLICAS_CEILING:-15000}"
+WORKER_MIN_REPLICAS_MAX_STEP_UP="${WORKER_MIN_REPLICAS_MAX_STEP_UP:-200}"
+WORKER_MIN_REPLICAS_MAX_STEP_DOWN="${WORKER_MIN_REPLICAS_MAX_STEP_DOWN:-50}"
+SIMULATIONS_PER_WARM_WORKER="${SIMULATIONS_PER_WARM_WORKER:-50}"
+ENFORCE_SIM_QUEUE_RATIO_FLOOR="${ENFORCE_SIM_QUEUE_RATIO_FLOOR:-1}"
+SIMULATIONS_PER_RUNNING_WORKER_FLOOR="${SIMULATIONS_PER_RUNNING_WORKER_FLOOR:-30}"
+MIN_SIMULATIONS_QUEUE_FLOOR="${MIN_SIMULATIONS_QUEUE_FLOOR:-800}"
+MAX_SIMULATIONS_QUEUE_FLOOR="${MAX_SIMULATIONS_QUEUE_FLOOR:-150000}"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+  printf '%s %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG_FILE"
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log "ERROR: required command not found: $cmd"
+    exit 1
+  fi
+}
+
+clamp() {
+  local value="$1"
+  local low="$2"
+  local high="$3"
+  if (( value < low )); then
+    echo "$low"
+  elif (( value > high )); then
+    echo "$high"
+  else
+    echo "$value"
+  fi
+}
+
+ceil_div() {
+  local numerator="$1"
+  local denominator="$2"
+  if (( denominator <= 0 )); then
+    echo 0
+    return
+  fi
+  echo $(( (numerator + denominator - 1) / denominator ))
+}
+
+redis_queue_depth() {
+  local pod_name="$1"
+  local queue_name="$2"
+  kubectl -n "$NAMESPACE" exec "$pod_name" -c "$REDIS_CONTAINER_NAME" -- \
+    redis-cli --no-auth-warning -a "$REDIS_PASSWORD" LLEN "$queue_name" 2>>"$LOG_FILE"
+}
+
+get_redis_pod() {
+  kubectl -n "$NAMESPACE" get pods -l "$REDIS_LABEL_SELECTOR" \
+    -o jsonpath='{.items[0].metadata.name}' 2>>"$LOG_FILE" || true
+}
+
+get_deployment_replicas() {
+  local deployment_name="$1"
+  kubectl -n "$NAMESPACE" get deployment "$deployment_name" \
+    -o jsonpath='{.spec.replicas}' 2>>"$LOG_FILE"
+}
+
+get_hpa_min_replicas() {
+  local hpa_name="$1"
+  kubectl -n "$NAMESPACE" get hpa "$hpa_name" \
+    -o jsonpath='{.spec.minReplicas}' 2>>"$LOG_FILE"
+}
+
+get_running_worker_pods() {
+  kubectl -n "$NAMESPACE" get pods -l "$WORKER_LABEL_SELECTOR" --field-selector=status.phase=Running \
+    --no-headers 2>>"$LOG_FILE" | wc -l | tr -d ' '
+}
+
+safe_int() {
+  local value="${1:-0}"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$value"
+  else
+    echo 0
+  fi
+}
+
+scale_web_background() {
+  local desired="$1"
+  local current
+  current="$(safe_int "$(get_deployment_replicas "$WEB_BACKGROUND_DEPLOYMENT")")"
+  if (( current == desired )); then
+    log "web-background replicas unchanged at $current"
+    return
+  fi
+
+  log "Scaling deployment/$WEB_BACKGROUND_DEPLOYMENT from $current to $desired"
+  kubectl -n "$NAMESPACE" scale deployment "$WEB_BACKGROUND_DEPLOYMENT" --replicas="$desired" >>"$LOG_FILE" 2>&1
+}
+
+web_background_managed_by_keda() {
+  kubectl -n "$NAMESPACE" get scaledobject "$WEB_BACKGROUND_DEPLOYMENT" >/dev/null 2>>"$LOG_FILE"
+}
+
+web_background_managed_by_hpa() {
+  kubectl -n "$NAMESPACE" get hpa "$WEB_BACKGROUND_DEPLOYMENT" >/dev/null 2>>"$LOG_FILE"
+}
+
+patch_worker_hpa_min() {
+  local desired="$1"
+  local current bounded_desired
+  current="$(safe_int "$(get_hpa_min_replicas "$WORKER_HPA_NAME")")"
+
+  bounded_desired="$desired"
+  if (( desired > current )) && (( WORKER_MIN_REPLICAS_MAX_STEP_UP > 0 )); then
+    local max_up_target=$(( current + WORKER_MIN_REPLICAS_MAX_STEP_UP ))
+    if (( desired > max_up_target )); then
+      bounded_desired="$max_up_target"
+    fi
+  elif (( desired < current )) && (( WORKER_MIN_REPLICAS_MAX_STEP_DOWN > 0 )); then
+    local max_down_target=$(( current - WORKER_MIN_REPLICAS_MAX_STEP_DOWN ))
+    if (( desired < max_down_target )); then
+      bounded_desired="$max_down_target"
+    fi
+  fi
+
+  if (( current == bounded_desired )); then
+    log "worker-hpa minReplicas unchanged at $current"
+    return
+  fi
+
+  if (( bounded_desired != desired )); then
+    log "Bounding worker-hpa minReplicas change from requested=$desired to bounded=$bounded_desired (current=$current)"
+  fi
+  log "Patching hpa/$WORKER_HPA_NAME minReplicas from $current to $bounded_desired"
+  kubectl -n "$NAMESPACE" patch hpa "$WORKER_HPA_NAME" --type merge \
+    -p "{\"spec\":{\"minReplicas\":$bounded_desired}}" >>"$LOG_FILE" 2>&1
+}
+
+run_cycle() {
+  local redis_pod raw_simulations raw_analyses raw_requeued simulations_depth analyses_depth requeued_depth
+  redis_pod="$(get_redis_pod)"
+  if [[ -z "$redis_pod" ]]; then
+    log "ERROR: no redis pod found with label selector '$REDIS_LABEL_SELECTOR'"
+    return 1
+  fi
+
+  raw_simulations="$(redis_queue_depth "$redis_pod" "$SIMULATIONS_QUEUE")"
+  raw_analyses="$(redis_queue_depth "$redis_pod" "$ANALYSES_QUEUE")"
+  raw_requeued="$(redis_queue_depth "$redis_pod" "$REQUEUED_QUEUE")"
+  simulations_depth="$(safe_int "$raw_simulations")"
+  analyses_depth="$(safe_int "$raw_analyses")"
+  requeued_depth="$(safe_int "$raw_requeued")"
+
+  # Effective simulation work = queued simulations + requeued simulations waiting to retry
+  local effective_sim_depth=$(( simulations_depth + requeued_depth ))
+
+  local desired_web_background desired_worker_min running_workers simulations_queue_floor low_simulations
+  desired_web_background="$(ceil_div "$analyses_depth" "$ANALYSES_PER_WEB_BACKGROUND")"
+  running_workers="$(safe_int "$(get_running_worker_pods)")"
+  simulations_queue_floor="$SIM_LOW_WATERMARK"
+  if (( ENFORCE_SIM_QUEUE_RATIO_FLOOR == 1 )); then
+    simulations_queue_floor=$(( running_workers * SIMULATIONS_PER_RUNNING_WORKER_FLOOR ))
+    simulations_queue_floor="$(clamp "$simulations_queue_floor" "$MIN_SIMULATIONS_QUEUE_FLOOR" "$MAX_SIMULATIONS_QUEUE_FLOOR")"
+  fi
+
+  low_simulations=0
+  if (( simulations_depth < simulations_queue_floor )); then
+    low_simulations=1
+  fi
+
+  if (( BOOST_WEB_BACKGROUND_WHEN_LOW_SIMS == 1 && low_simulations == 1 && analyses_depth > 0 )); then
+    desired_web_background=$(( desired_web_background + LOW_SIM_QUEUE_WEB_BACKGROUND_BOOST ))
+  fi
+  desired_web_background="$(clamp "$desired_web_background" "$WEB_BACKGROUND_MIN_REPLICAS" "$WEB_BACKGROUND_MAX_REPLICAS")"
+
+  desired_worker_min="$(ceil_div "$effective_sim_depth" "$SIMULATIONS_PER_WARM_WORKER")"
+  desired_worker_min="$(clamp "$desired_worker_min" "$WORKER_MIN_REPLICAS_FLOOR" "$WORKER_MIN_REPLICAS_CEILING")"
+
+  log "Queue depth: simulations=$simulations_depth requeued=$requeued_depth effectiveSim=$effective_sim_depth analyses=$analyses_depth runningWorkers=$running_workers requiredSimFloor=$simulations_queue_floor lowSimulations=$low_simulations"
+  log "Target scale: web-background=$desired_web_background worker-hpa.minReplicas=$desired_worker_min"
+
+  if web_background_managed_by_keda; then
+    log "web-background KEDA ScaledObject detected; skipping direct replica management"
+  elif web_background_managed_by_hpa; then
+    log "web-background HPA detected; skipping direct replica management"
+  elif (( MANAGE_WEB_BACKGROUND == 1 )); then
+    scale_web_background "$desired_web_background"
+  fi
+  patch_worker_hpa_min "$desired_worker_min"
+}
+
+main() {
+  require_cmd kubectl
+
+  log "Queue autoscale loop starting (namespace=$NAMESPACE interval=${INTERVAL_SECONDS}s once=$ONCE)"
+  while true; do
+    if ! run_cycle; then
+      log "Cycle failed; leaving current scaling unchanged"
+    fi
+
+    if [[ "$ONCE" == "1" ]]; then
+      break
+    fi
+
+    sleep "$INTERVAL_SECONDS"
+  done
+}
+
+main "$@"

--- a/scripts/remediate-stalled-analyses.sh
+++ b/scripts/remediate-stalled-analyses.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openstudio-server}"
+LOOKBACK_HOURS="${LOOKBACK_HOURS:-6}"
+STALL_MINUTES="${STALL_MINUTES:-10}"
+MAX_ANALYSES="${MAX_ANALYSES:-25}"
+ANALYSIS_ID="${ANALYSIS_ID:-}"
+ONCE="${ONCE:-1}"
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-120}"
+EXECUTE="${EXECUTE:-0}"
+LOG_FILE="${LOG_FILE:-./stalled-analysis-remediation-${NAMESPACE}-$(date +%Y%m%d-%H%M%S).log}"
+
+DB_LABEL_SELECTOR="${DB_LABEL_SELECTOR:-app=db}"
+DB_CONTAINER_NAME="${DB_CONTAINER_NAME:-mongo-db}"
+MONGO_URI="${MONGO_URI:-mongodb://openstudio:openstudio@localhost:27017/?authSource=admin}"
+MONGO_DB_NAME="${MONGO_DB_NAME:-os_docker}"
+
+REDIS_LABEL_SELECTOR="${REDIS_LABEL_SELECTOR:-app=redis}"
+REDIS_CONTAINER_NAME="${REDIS_CONTAINER_NAME:-redis}"
+REDIS_PASSWORD="${REDIS_PASSWORD:-openstudio}"
+
+WEB_LABEL_SELECTOR="${WEB_LABEL_SELECTOR:-app=web}"
+WEB_CONTAINER_NAME="${WEB_CONTAINER_NAME:-web}"
+WEB_ACTION_URL_BASE="${WEB_ACTION_URL_BASE:-http://127.0.0.1}"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  remediate-stalled-analyses.sh [options]
+
+Description:
+  Detect analyses with only `data_points.status=na` and no queue progress,
+  clear stale Redis analysis keys, and optionally re-trigger analysis start.
+
+Default mode is dry-run (no writes). Use --execute to apply changes.
+
+Options:
+  -n, --namespace <name>         Kubernetes namespace (default: openstudio-server)
+  --lookback-hours <hours>       Search recent analyses by datapoint creation window (default: 6)
+  --stall-minutes <minutes>      Minimum inactivity age to treat as stalled (default: 10)
+  --max-analyses <count>         Max stalled analyses to process per cycle (default: 25)
+  --analysis-id <id>             Only process one analysis id
+  --execute                      Apply changes (clear keys + POST action.json)
+  --once                         Run one cycle and exit (default)
+  --loop                         Run continuously
+  --interval-seconds <seconds>   Sleep between cycles in loop mode (default: 120)
+  --help                         Show this help text
+
+Examples:
+  # Safe preview
+  ./scripts/remediate-stalled-analyses.sh --lookback-hours 12 --stall-minutes 15
+
+  # Execute remediation for one known stuck analysis
+  ./scripts/remediate-stalled-analyses.sh --analysis-id <analysis-id> --execute
+USAGE
+}
+
+log() {
+  printf '%s %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG_FILE"
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log "ERROR: required command not found: $cmd"
+    exit 1
+  fi
+}
+
+is_int() {
+  [[ "${1:-}" =~ ^[0-9]+$ ]]
+}
+
+get_pod_name() {
+  local selector="$1"
+  kubectl -n "$NAMESPACE" get pods -l "$selector" -o jsonpath='{.items[0].metadata.name}' 2>>"$LOG_FILE" || true
+}
+
+find_stalled_analyses() {
+  local db_pod="$1"
+  local analysis_filter_js=""
+  if [[ -n "$ANALYSIS_ID" ]]; then
+    analysis_filter_js="if (analysisId !== '$ANALYSIS_ID') { continue; }"
+  fi
+
+  local js
+  js="$(cat <<EOF
+const dbName = "$MONGO_DB_NAME";
+const lookbackHours = $LOOKBACK_HOURS;
+const stallMinutes = $STALL_MINUTES;
+const maxAnalyses = $MAX_ANALYSES;
+const cutoff = new Date(Date.now() - (lookbackHours * 60 * 60 * 1000));
+const mongoDb = db.getSiblingDB(dbName);
+
+const grouped = mongoDb.data_points.aggregate([
+  { \$match: { created_at: { \$gte: cutoff } } },
+  { \$group: {
+      _id: { analysis_id: "\$analysis_id", status: "\$status" },
+      n: { \$sum: 1 },
+      latest_dp_update: { \$max: "\$updated_at" }
+    }
+  },
+  { \$group: {
+      _id: "\$_id.analysis_id",
+      status_pairs: { \$push: { k: "\$_id.status", v: "\$n" } },
+      latest_dp_update: { \$max: "\$latest_dp_update" }
+    }
+  },
+  { \$project: {
+      _id: 1,
+      counts: { \$arrayToObject: "\$status_pairs" },
+      latest_dp_update: 1
+    }
+  },
+  { \$sort: { latest_dp_update: -1 } },
+  { \$limit: 5000 }
+]).toArray();
+
+let emitted = 0;
+for (const row of grouped) {
+  if (emitted >= maxAnalyses) { break; }
+  const analysisId = row._id;
+  $analysis_filter_js
+  const counts = row.counts || {};
+  const naCount = counts.na || 0;
+  const queuedCount = counts.queued || 0;
+  const startedCount = counts.started || 0;
+  const completedCount = counts.completed || 0;
+  if (!(naCount > 0 && queuedCount === 0 && startedCount === 0 && completedCount === 0)) {
+    continue;
+  }
+  const analysis = mongoDb.analyses.findOne({ _id: analysisId }, { name: 1, updated_at: 1 });
+  const latest = row.latest_dp_update || (analysis && analysis.updated_at);
+  if (!latest) {
+    continue;
+  }
+  const ageMinutes = Math.floor((Date.now() - new Date(latest).getTime()) / 60000);
+  if (ageMinutes < stallMinutes) {
+    continue;
+  }
+  const safeName = ((analysis && analysis.name) || "").replace(/[\\t\\n\\r]/g, " ");
+  print([analysisId, safeName, naCount, new Date(latest).toISOString(), ageMinutes].join("\\t"));
+  emitted += 1;
+}
+void 0;
+EOF
+)"
+
+  kubectl -n "$NAMESPACE" exec "$db_pod" -c "$DB_CONTAINER_NAME" -- \
+    mongosh --quiet "$MONGO_URI" --eval "$js" 2>>"$LOG_FILE" || true
+}
+
+clear_analysis_locks() {
+  local redis_pod="$1"
+  local analysis_id="$2"
+  local queuing_key="resque:analysis:${analysis_id}:queuing"
+  local completed_key="resque:analysis:${analysis_id}:completed"
+  local removed
+  removed="$(kubectl -n "$NAMESPACE" exec "$redis_pod" -c "$REDIS_CONTAINER_NAME" -- \
+    redis-cli --no-auth-warning -a "$REDIS_PASSWORD" DEL "$queuing_key" "$completed_key" 2>>"$LOG_FILE" || true)"
+  log "Cleared Redis keys for analysis=$analysis_id removed=${removed:-0} keys=[$queuing_key,$completed_key]"
+}
+
+trigger_analysis_start() {
+  local web_pod="$1"
+  local analysis_id="$2"
+  local url="${WEB_ACTION_URL_BASE}/analyses/${analysis_id}/action.json"
+  local payload='{"analysis_action":"start"}'
+  local response http_code body
+
+  response="$(kubectl -n "$NAMESPACE" exec "$web_pod" -c "$WEB_CONTAINER_NAME" -- sh -lc \
+    "curl -sS -X POST '$url' -H 'Content-Type: application/json' --data '$payload' -w ' HTTP_STATUS:%{http_code}'" 2>>"$LOG_FILE" || true)"
+  http_code="${response##*HTTP_STATUS:}"
+  body="${response% HTTP_STATUS:*}"
+
+  if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+    log "Triggered action.json start for analysis=$analysis_id status=$http_code"
+    return 0
+  fi
+
+  log "ERROR: action.json start failed for analysis=$analysis_id status=${http_code:-unknown} body=${body:-<empty>}"
+  return 1
+}
+
+run_cycle() {
+  local db_pod redis_pod web_pod
+  db_pod="$(get_pod_name "$DB_LABEL_SELECTOR")"
+  redis_pod="$(get_pod_name "$REDIS_LABEL_SELECTOR")"
+  web_pod="$(get_pod_name "$WEB_LABEL_SELECTOR")"
+
+  if [[ -z "$db_pod" || -z "$redis_pod" || -z "$web_pod" ]]; then
+    log "ERROR: missing required pod(s): db=$db_pod redis=$redis_pod web=$web_pod"
+    return 1
+  fi
+
+  local rows
+  rows="$(find_stalled_analyses "$db_pod")"
+  if [[ -z "$rows" ]]; then
+    log "No stalled analyses found (lookback=${LOOKBACK_HOURS}h stall=${STALL_MINUTES}m)"
+    return 0
+  fi
+
+  local count=0 started=0 failed=0
+  while IFS=$'\t' read -r analysis_id analysis_name na_count latest_ts age_minutes; do
+    [[ -z "${analysis_id:-}" ]] && continue
+    [[ ! "${analysis_id}" =~ ^[0-9a-fA-F-]{36}$ ]] && continue
+    count=$((count + 1))
+    log "Candidate stalled analysis id=$analysis_id name=\"$analysis_name\" na=$na_count latest=$latest_ts ageMin=$age_minutes"
+    if [[ "$EXECUTE" != "1" ]]; then
+      continue
+    fi
+
+    clear_analysis_locks "$redis_pod" "$analysis_id"
+    if trigger_analysis_start "$web_pod" "$analysis_id"; then
+      started=$((started + 1))
+    else
+      failed=$((failed + 1))
+    fi
+  done <<<"$rows"
+
+  if [[ "$EXECUTE" == "1" ]]; then
+    log "Cycle summary execute=1 candidates=$count startTriggered=$started startFailed=$failed"
+  else
+    log "Cycle summary execute=0 candidates=$count"
+  fi
+}
+
+main() {
+  require_cmd kubectl
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -n|--namespace)
+        NAMESPACE="$2"
+        shift 2
+        ;;
+      --lookback-hours)
+        LOOKBACK_HOURS="$2"
+        shift 2
+        ;;
+      --stall-minutes)
+        STALL_MINUTES="$2"
+        shift 2
+        ;;
+      --max-analyses)
+        MAX_ANALYSES="$2"
+        shift 2
+        ;;
+      --analysis-id)
+        ANALYSIS_ID="$2"
+        shift 2
+        ;;
+      --execute)
+        EXECUTE=1
+        shift
+        ;;
+      --once)
+        ONCE=1
+        shift
+        ;;
+      --loop)
+        ONCE=0
+        shift
+        ;;
+      --interval-seconds)
+        INTERVAL_SECONDS="$2"
+        shift 2
+        ;;
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        log "ERROR: unknown argument: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+
+  if ! is_int "$LOOKBACK_HOURS" || ! is_int "$STALL_MINUTES" || ! is_int "$MAX_ANALYSES" || ! is_int "$INTERVAL_SECONDS"; then
+    log "ERROR: lookback-hours, stall-minutes, max-analyses, and interval-seconds must be integers"
+    exit 1
+  fi
+
+  log "Stalled analysis remediation starting (namespace=$NAMESPACE execute=$EXECUTE once=$ONCE)"
+  log "Config: lookbackHours=$LOOKBACK_HOURS stallMinutes=$STALL_MINUTES maxAnalyses=$MAX_ANALYSES analysisId=${ANALYSIS_ID:-<all>}"
+
+  while true; do
+    if ! run_cycle; then
+      log "Cycle failed; no further action taken for this cycle"
+    fi
+
+    if [[ "$ONCE" == "1" ]]; then
+      break
+    fi
+    sleep "$INTERVAL_SECONDS"
+  done
+}
+
+main "$@"

--- a/scripts/worker-staged-ramp.sh
+++ b/scripts/worker-staged-ramp.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openstudio-server}"
+WORKER_HPA_NAME="${WORKER_HPA_NAME:-worker-hpa}"
+WORKER_DEPLOYMENT="${WORKER_DEPLOYMENT:-worker}"
+WORKER_LABEL_SELECTOR="${WORKER_LABEL_SELECTOR:-app=worker}"
+STAGES="${STAGES:-2000,5000,10000,15000}"
+
+MIN_READY_RATIO="${MIN_READY_RATIO:-0.95}"
+HOLD_SECONDS="${HOLD_SECONDS:-180}"
+CHECK_INTERVAL_SECONDS="${CHECK_INTERVAL_SECONDS:-15}"
+STAGE_TIMEOUT_SECONDS="${STAGE_TIMEOUT_SECONDS:-1800}"
+
+SANDBOX_FAIL_THRESHOLD_5M="${SANDBOX_FAIL_THRESHOLD_5M:-100}"
+MAX_NON_RUNNING_ABS="${MAX_NON_RUNNING_ABS:-200}"
+MAX_CREATE_CONTAINER_ERROR_ABS="${MAX_CREATE_CONTAINER_ERROR_ABS:-25}"
+MAX_TERMINATING_ABS="${MAX_TERMINATING_ABS:-200}"
+
+STAGE_SET_MIN_REPLICAS="${STAGE_SET_MIN_REPLICAS:-0}"
+LOG_FILE="${LOG_FILE:-./worker-staged-ramp-${NAMESPACE}-$(date +%Y%m%d-%H%M%S).log}"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+  printf '%s %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG_FILE"
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log "ERROR: required command not found: $cmd"
+    exit 1
+  fi
+}
+
+safe_int() {
+  local value="${1:-0}"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$value"
+  else
+    echo 0
+  fi
+}
+
+get_hpa_min() {
+  safe_int "$(kubectl -n "$NAMESPACE" get hpa "$WORKER_HPA_NAME" -o jsonpath='{.spec.minReplicas}' 2>>"$LOG_FILE" || true)"
+}
+
+set_hpa_stage_limit() {
+  local stage="$1"
+  local current_min desired_min
+  current_min="$(get_hpa_min)"
+  desired_min="$current_min"
+
+  if (( STAGE_SET_MIN_REPLICAS == 1 || current_min > stage )); then
+    desired_min="$stage"
+  fi
+
+  log "Patching hpa/$WORKER_HPA_NAME to stage target: maxReplicas=$stage minReplicas=$desired_min"
+  kubectl -n "$NAMESPACE" patch hpa "$WORKER_HPA_NAME" --type merge \
+    -p "{\"spec\":{\"maxReplicas\":$stage,\"minReplicas\":$desired_min}}" >>"$LOG_FILE" 2>&1
+}
+
+scale_worker_deployment() {
+  local replicas="$1"
+  log "Scaling deployment/$WORKER_DEPLOYMENT to replicas=$replicas"
+  kubectl -n "$NAMESPACE" scale deployment "$WORKER_DEPLOYMENT" --replicas="$replicas" >>"$LOG_FILE" 2>&1 || true
+}
+
+failed_sandbox_events_5m() {
+  local cutoff
+  cutoff="$(($(date -u +%s) - 300))"
+  kubectl -n "$NAMESPACE" get events --field-selector type=Warning -o json 2>>"$LOG_FILE" \
+    | jq -r --argjson cutoff "$cutoff" '
+      [
+        .items[]
+        | select(.reason == "FailedCreatePodSandBox")
+        | (.lastTimestamp // .eventTime // .metadata.creationTimestamp // "") as $ts
+        | select($ts != "")
+        | select((($ts | fromdateiso8601?) // 0) >= $cutoff)
+      ] | length
+    ' 2>>"$LOG_FILE"
+}
+
+worker_pod_metrics() {
+  kubectl -n "$NAMESPACE" get pods -l "$WORKER_LABEL_SELECTOR" -o json 2>>"$LOG_FILE" \
+    | jq -r '
+      def waiting_reason($r):
+        any((.status.containerStatuses // [])[]?; (.state.waiting.reason // "") == $r);
+      .items as $items
+      | {
+          total: ($items | length),
+          running: ($items | map(select(.status.phase == "Running")) | length),
+          non_running: ($items | map(select(.status.phase != "Running")) | length),
+          terminating: ($items | map(select(.metadata.deletionTimestamp != null)) | length),
+          create_container_error: ($items | map(select(waiting_reason("CreateContainerError"))) | length)
+        }
+      | [.total, .running, .non_running, .terminating, .create_container_error]
+      | @tsv
+    ' 2>>"$LOG_FILE"
+}
+
+deployment_ready_replicas() {
+  safe_int "$(kubectl -n "$NAMESPACE" get deploy "$WORKER_DEPLOYMENT" -o jsonpath='{.status.readyReplicas}' 2>>"$LOG_FILE" || true)"
+}
+
+rollback_to_stage() {
+  local rollback_stage="$1"
+  log "ROLLBACK: reverting worker scale limits to stage=$rollback_stage"
+  set_hpa_stage_limit "$rollback_stage"
+  scale_worker_deployment "$rollback_stage"
+}
+
+validate_stage() {
+  local stage="$1"
+  local rollback_stage="$2"
+  local stage_start healthy_since
+
+  stage_start="$(date -u +%s)"
+  healthy_since=0
+
+  while true; do
+    local now elapsed healthy_elapsed sandbox_5m
+    now="$(date -u +%s)"
+    elapsed=$((now - stage_start))
+    sandbox_5m="$(safe_int "$(failed_sandbox_events_5m)")"
+
+    local metrics total running non_running terminating create_error ready min_ready
+    metrics="$(worker_pod_metrics)"
+    total="$(safe_int "$(awk '{print $1}' <<<"$metrics")")"
+    running="$(safe_int "$(awk '{print $2}' <<<"$metrics")")"
+    non_running="$(safe_int "$(awk '{print $3}' <<<"$metrics")")"
+    terminating="$(safe_int "$(awk '{print $4}' <<<"$metrics")")"
+    create_error="$(safe_int "$(awk '{print $5}' <<<"$metrics")")"
+    ready="$(deployment_ready_replicas)"
+    min_ready="$(awk -v s="$stage" -v r="$MIN_READY_RATIO" 'BEGIN { printf("%d", s*r) }')"
+
+    log "Stage=$stage elapsed=${elapsed}s ready=$ready running=$running total=$total nonRunning=$non_running terminating=$terminating createContainerError=$create_error failedCreatePodSandbox5m=$sandbox_5m"
+
+    if (( sandbox_5m > SANDBOX_FAIL_THRESHOLD_5M )); then
+      log "ERROR: failed sandbox events exceeded threshold ($sandbox_5m > $SANDBOX_FAIL_THRESHOLD_5M)"
+      rollback_to_stage "$rollback_stage"
+      return 1
+    fi
+
+    if (( elapsed > STAGE_TIMEOUT_SECONDS )); then
+      log "ERROR: stage timeout exceeded for target=$stage (${elapsed}s > ${STAGE_TIMEOUT_SECONDS}s)"
+      rollback_to_stage "$rollback_stage"
+      return 1
+    fi
+
+    if (( ready >= min_ready )) \
+      && (( non_running <= MAX_NON_RUNNING_ABS )) \
+      && (( create_error <= MAX_CREATE_CONTAINER_ERROR_ABS )) \
+      && (( terminating <= MAX_TERMINATING_ABS )); then
+      if (( healthy_since == 0 )); then
+        healthy_since="$now"
+      fi
+      healthy_elapsed=$((now - healthy_since))
+      if (( healthy_elapsed >= HOLD_SECONDS )); then
+        log "Stage target=$stage passed health hold (${healthy_elapsed}s >= ${HOLD_SECONDS}s)"
+        return 0
+      fi
+    else
+      healthy_since=0
+    fi
+
+    sleep "$CHECK_INTERVAL_SECONDS"
+  done
+}
+
+main() {
+  require_cmd kubectl
+  require_cmd jq
+
+  IFS=',' read -r -a stage_list <<<"$STAGES"
+  if (( ${#stage_list[@]} == 0 )); then
+    log "ERROR: STAGES is empty"
+    exit 1
+  fi
+
+  local previous_stage current_ready
+  current_ready="$(deployment_ready_replicas)"
+  previous_stage="$current_ready"
+
+  log "Starting staged worker ramp for namespace=$NAMESPACE stages=$STAGES"
+  log "Gate config: minReadyRatio=$MIN_READY_RATIO hold=${HOLD_SECONDS}s timeout=${STAGE_TIMEOUT_SECONDS}s sandboxFailThreshold5m=$SANDBOX_FAIL_THRESHOLD_5M"
+
+  local stage
+  for stage in "${stage_list[@]}"; do
+    stage="$(safe_int "$stage")"
+    if (( stage <= 0 )); then
+      log "ERROR: invalid stage value '$stage'"
+      exit 1
+    fi
+
+    if (( stage < previous_stage )); then
+      log "ERROR: stage values must be non-decreasing (stage=$stage previous=$previous_stage)"
+      exit 1
+    fi
+
+    set_hpa_stage_limit "$stage"
+    if ! validate_stage "$stage" "$previous_stage"; then
+      exit 1
+    fi
+    previous_stage="$stage"
+  done
+
+  log "Completed staged worker ramp successfully. Final stage=$previous_stage"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds four new operational scripts for managing large-scale batch simulation runs, plus significant improvements to the existing health remediation loop.

## New Scripts

### `scripts/queue-autoscale-loop.sh`
Continuously adjusts worker HPA `minReplicas` and `web-background` replicas based on live queue depths:
- Ratio-based simulation queue floor (e.g. 30 queued jobs per running worker)
- Bounded scale step limits to prevent runaway scaling
- Optional direct `web-background` replica management (vs deferring to HPA)
- Configurable via env vars; meant to run alongside the health loop

### `scripts/worker-staged-ramp.sh`
Ramps worker HPA `maxReplicas` through stages (default: 2k → 5k → 10k → 15k):
- Validates readiness ratio, non-running pod count, sandbox failure rate,
  CreateContainerError counts, and Terminating pod count before advancing
- Auto-rolls back to last stable stage on guardrail breach
- Hold period at each stage before advancing

### `scripts/remediate-stalled-analyses.sh`
Detects analyses stuck in `na`/`queued` state with no queue activity:
- Dry-run by default; requires `--execute` flag to act
- Supports `--analysis-id` for targeted remediation

### `scripts/clean-data.sh`
Safely deletes projects, analyses, Redis queues, and optionally PVs for a fresh deployment start. Supports dry-run, force mode, and PV deletion.

## Updated: `scripts/health-remediation-loop.sh`
- Add CNI sandbox timeout detection: identifies pods stuck with
  `FailedCreatePodSandBox + DeadlineExceeded`, restarts `aws-node` on the
  affected node with a configurable cooldown (`CNI_RESTART_COOLDOWN_SECONDS`)
- Cap CNI restarts per cycle (`MAX_CNI_RESTARTS_PER_CYCLE`)
- Update default HPA scaling parameters to match 15k scaling targets
- Add `ENFORCE_WORKER_HPA_MAX_REPLICAS` flag (0 = disabled, N = enforce max)